### PR TITLE
Avoid memory copies for non-native 64-bit float arrays

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: quay.io/pypa/manylinux1_i686
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: /opt/python/cp36-cp36m/bin/pip install numpy pytest hypothesis[numpy]
+      - run:
+          name: Build extension
+          command: /opt/python/cp36-cp36m/bin/python setup.py build_ext --inplace
+      - run:
+          name: Run tests
+          command: /opt/python/cp36-cp36m/bin/pytest fast_histogram -p no:warnings --hypothesis-show-statistics

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Fix bug that caused histograms of n-dimensional arrays to
   not be computed correctly. [#21]
 
+- Avoid memory copies for non-native endian 64-bit float arrays. [#18]
+
 0.4 (2018-02-12)
 ----------------
 

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -56,10 +56,11 @@ MOD_INIT(_histogram_core)
 
 
 double byteswap_f64(double value){
+    int i;
     double result;
     char *orig = (char *)&value;
     char *dest = (char *)&result;
-    for(int i=0; i<DOUBLE_SIZE; i++) dest[i] = orig[DOUBLE_SIZE - i - 1];
+    for(i=0; i<DOUBLE_SIZE; i++) dest[i] = orig[DOUBLE_SIZE - i - 1];
     return result;
 }
 

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -239,8 +239,8 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args)
     }
 
     /* Interpret the input objects as `numpy` arrays. */
-    x_array = PyArray_FROM_OTF(x_obj, NPY_DOUBLE, NPY_IN_ARRAY);
-    w_array = PyArray_FROM_OTF(w_obj, NPY_DOUBLE, NPY_IN_ARRAY);
+    x_array = PyArray_FROM_O(x_obj);
+    w_array = PyArray_FROM_O(w_obj);
 
     /* If that didn't work, throw an `Exception`. */
     if (x_array == NULL || w_array == NULL) {
@@ -324,9 +324,9 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args)
     }
 
     /* Interpret the input objects as `numpy` arrays. */
-    x_array = PyArray_FROM_OTF(x_obj, NPY_DOUBLE, NPY_IN_ARRAY);
-    y_array = PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_IN_ARRAY);
-    w_array = PyArray_FROM_OTF(w_obj, NPY_DOUBLE, NPY_IN_ARRAY);
+    x_array = PyArray_FROM_O(x_obj);
+    y_array = PyArray_FROM_O(y_obj);
+    w_array = PyArray_FROM_O(w_obj);
 
     /* If that didn't work, throw an `Exception`. */
     if (x_array == NULL || y_array == NULL || w_array == NULL) {
@@ -387,7 +387,7 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args)
       if (tx >= xmin && tx < xmax && ty >= ymin && ty < ymax) {
           ix = (tx - xmin) * normx * fnx;
           iy = (ty - ymin) * normy * fny;
-          count[iy + ny * ix] += w[i];
+          count[iy + ny * ix] += tw;
       }
 
     }

--- a/fast_histogram/histogram.py
+++ b/fast_histogram/histogram.py
@@ -12,6 +12,15 @@ from ._histogram_core import (_histogram1d,
 __all__ = ['histogram1d', 'histogram2d']
 
 
+def byteswap_if_needed(array):
+    if array.dtype.kind == 'f' and array.dtype.itemsize == 8 and array.flags.c_contiguous:
+        byteswap = int(not array.dtype.isnative)
+    else:
+        array = np.ascontiguousarray(array, np.float)
+        byteswap = 0
+    return array, byteswap
+
+
 def histogram1d(x, bins, range, weights=None):
     """
     Compute a 1D histogram assuming equally spaced bins.
@@ -48,16 +57,16 @@ def histogram1d(x, bins, range, weights=None):
     if nx <= 0:
         raise ValueError("nx should be strictly positive")
 
-    x = np.ascontiguousarray(x, np.float)
+    x, xbyteswap = byteswap_if_needed(x)
 
     if x.ndim > 1:
         x = x.ravel()
 
     if weights is None:
-        return _histogram1d(x, nx, xmin, xmax)
+        return _histogram1d(x, nx, xmin, xmax, xbyteswap)
     else:
-        weights = np.ascontiguousarray(weights, np.float)
-        return _histogram1d_weighted(x, weights, nx, xmin, xmax)
+        weights, wbyteswap = byteswap_if_needed(weights)
+        return _histogram1d_weighted(x, weights, nx, xmin, xmax, xbyteswap, wbyteswap)
 
 
 def histogram2d(x, y, bins, range, weights=None):
@@ -114,8 +123,8 @@ def histogram2d(x, y, bins, range, weights=None):
     if ny <= 0:
         raise ValueError("ny should be strictly positive")
 
-    x = np.ascontiguousarray(x, np.float)
-    y = np.ascontiguousarray(y, np.float)
+    x, xbyteswap = byteswap_if_needed(x)
+    y, ybyteswap = byteswap_if_needed(y)
 
     if x.ndim > 1:
         x = x.ravel()
@@ -124,7 +133,7 @@ def histogram2d(x, y, bins, range, weights=None):
         y = y.ravel()
 
     if weights is None:
-        return _histogram2d(x, y, nx, xmin, xmax, ny, ymin, ymax)
+        return _histogram2d(x, y, nx, xmin, xmax, ny, ymin, ymax, xbyteswap, ybyteswap)
     else:
-        weights = np.ascontiguousarray(weights, np.float)
-        return _histogram2d_weighted(x, y, weights, nx, xmin, xmax, ny, ymin, ymax)
+        weights, wbyteswap = byteswap_if_needed(weights)
+        return _histogram2d_weighted(x, y, weights, nx, xmin, xmax, ny, ymin, ymax, xbyteswap, ybyteswap, wbyteswap)

--- a/fast_histogram/histogram.py
+++ b/fast_histogram/histogram.py
@@ -13,7 +13,8 @@ __all__ = ['histogram1d', 'histogram2d']
 
 
 def byteswap_if_needed(array):
-    if array.dtype.kind == 'f' and array.dtype.itemsize == 8 and array.flags.c_contiguous:
+    if (isinstance(array, np.ndarray) and array.dtype.kind == 'f'
+            and array.dtype.itemsize == 8 and array.flags.c_contiguous):
         byteswap = int(not array.dtype.isnative)
     else:
         array = np.ascontiguousarray(array, np.float)
@@ -61,6 +62,9 @@ def histogram1d(x, bins, range, weights=None):
 
     if x.ndim > 1:
         x = x.ravel()
+
+    if x.size == 0:
+        return np.zeros(nx)
 
     if weights is None:
         return _histogram1d(x, nx, xmin, xmax, xbyteswap)

--- a/fast_histogram/tests/test_histogram.py
+++ b/fast_histogram/tests/test_histogram.py
@@ -15,16 +15,17 @@ from ..histogram import histogram1d, histogram2d
 @given(size=st.integers(0, 100),
        nx=st.integers(1, 10),
        xmin=st.floats(-1e10, 1e10), xmax=st.floats(-1e10, 1e10),
-       weights=st.booleans())
+       weights=st.booleans(),
+       dtype=st.sampled_from(['>f8', '<f8']))
 @settings(max_examples=5000)
-def test_1d_compare_with_numpy(size, nx, xmin, xmax, weights):
+def test_1d_compare_with_numpy(size, nx, xmin, xmax, weights, dtype):
 
     if xmax <= xmin:
         return
 
-    x = arrays(np.float, size, elements=st.floats(-1000, 1000)).example()
+    x = arrays(dtype, size, elements=st.floats(-1000, 1000)).example()
     if weights:
-        w = arrays(np.float, size, elements=st.floats(-1000, 1000)).example()
+        w = arrays(dtype, size, elements=st.floats(-1000, 1000)).example()
     else:
         w = None
 
@@ -49,19 +50,21 @@ def test_1d_compare_with_numpy(size, nx, xmin, xmax, weights):
        xmin=st.floats(-1e10, 1e10), xmax=st.floats(-1e10, 1e10),
        ny=st.integers(1, 10),
        ymin=st.floats(-1e10, 1e10), ymax=st.floats(-1e10, 1e10),
-       weights=st.booleans())
+       weights=st.booleans(),
+       dtype=st.sampled_from(['>f8', '<f8']))
 @settings(max_examples=5000)
-@example(size=5, nx=1, xmin=0.0, xmax=84.17833763374462, ny=1, ymin=-999999999.9999989, ymax=0.0, weights=False)
-@example(size=1, nx=1, xmin=-2.2204460492503135e-06, xmax=0.0, ny=1, ymin=0.0, ymax=1.1102230246251567e-05, weights=False)
-def test_2d_compare_with_numpy(size, nx, xmin, xmax, ny, ymin, ymax, weights):
+@example(size=5, nx=1, xmin=0.0, xmax=84.17833763374462, ny=1, ymin=-999999999.9999989, ymax=0.0, weights=False, dtype='<f8')
+@example(size=1, nx=1, xmin=-2.2204460492503135e-06, xmax=0.0, ny=1, ymin=0.0, ymax=1.1102230246251567e-05, weights=False, dtype='<f8')
+@example(size=3, nx=1, xmin=0.0, xmax=841.7833941010146, ny=1, ymin=-135.92383885097095, ymax=0.0, weights=True, dtype='>f8')
+def test_2d_compare_with_numpy(size, nx, xmin, xmax, ny, ymin, ymax, weights, dtype):
 
     if xmax <= xmin or ymax <= ymin:
         return
 
-    x = arrays(np.float, size, elements=st.floats(-1000, 1000)).example()
-    y = arrays(np.float, size, elements=st.floats(-1000, 1000)).example()
+    x = arrays(dtype, size, elements=st.floats(-1000, 1000)).example()
+    y = arrays(dtype, size, elements=st.floats(-1000, 1000)).example()
     if weights:
-        w = arrays(np.float, size, elements=st.floats(-1000, 1000)).example()
+        w = arrays(dtype, size, elements=st.floats(-1000, 1000)).example()
     else:
         w = None
 
@@ -103,3 +106,16 @@ def test_nd_arrays():
                             bins=(10, 10), range=[(0, 1), (0, 1)])
 
     np.testing.assert_equal(result_1d, result_3d)
+
+
+def test_list():
+
+    # Make sure that lists can be passed in
+
+    x_list = [1.4, 2.1, 4.2]
+    x_arr = np.array(x_list)
+
+    result_list = histogram1d(x_list, bins=10, range=(0, 10))
+    result_arr = histogram1d(x_arr, bins=10, range=(0, 10))
+
+    np.testing.assert_equal(result_list, result_arr)


### PR DESCRIPTION
This does byte-swapping on-the-fly - before merging I need to double check the performance impact.

This also breaks compatibility with people who might pass lists of data - need to add a test for that!