### PR TITLE
Add float-32 support

### DIFF
--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -92,6 +92,9 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args)
         return NULL;
     }
 
+    /* Releasing GIL, no allocation/referencing allowed
+     (see `ndarraytypes.h` for macros) */
+    Py_BEGIN_ALLOW_THREADS
     PyArray_FILLWBYTE(count_array, 0);
 
     /* Get pointers to the data as C-types. */
@@ -112,8 +115,9 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args)
       }
 
     }
-
+    
     /* Clean up. */
+    Py_END_ALLOW_THREADS
     Py_DECREF(x_array);
 
     return count_array;
@@ -172,6 +176,9 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args)
         return NULL;
     }
 
+    /* Releasing GIL, no allocation/referencing allowed
+     (see `ndarraytypes.h` for macros) */
+    Py_BEGIN_ALLOW_THREADS
     PyArray_FILLWBYTE(count_array, 0);
 
     /* Get pointers to the data as C-types. */
@@ -196,8 +203,9 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args)
       }
 
     }
-
+    
     /* Clean up. */
+    Py_END_ALLOW_THREADS
     Py_DECREF(x_array);
     Py_DECREF(y_array);
 
@@ -256,6 +264,9 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args)
         return NULL;
     }
 
+    /* Releasing GIL, no allocation/referencing allowed
+     (see `ndarraytypes.h` for macros) */
+    Py_BEGIN_ALLOW_THREADS
     PyArray_FILLWBYTE(count_array, 0);
 
     /* Get pointers to the data as C-types. */
@@ -279,6 +290,7 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args)
     }
 
     /* Clean up. */
+    Py_END_ALLOW_THREADS
     Py_DECREF(x_array);
     Py_DECREF(w_array);
 
@@ -341,6 +353,9 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args)
         return NULL;
     }
 
+    /* Releasing GIL, no allocation/referencing allowed
+     (see `ndarraytypes.h` for macros) */
+    Py_BEGIN_ALLOW_THREADS
     PyArray_FILLWBYTE(count_array, 0);
 
     /* Get pointers to the data as C-types. */
@@ -368,6 +383,7 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args)
     }
 
     /* Clean up. */
+    Py_END_ALLOW_THREADS
     Py_DECREF(x_array);
     Py_DECREF(y_array);
     Py_DECREF(w_array);

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -14,6 +14,10 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args);
 static PyObject *_histogram2d(PyObject *self, PyObject *args);
 static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args);
 static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args);
+static PyObject *_histogram1d_f32(PyObject *self, PyObject *args);
+static PyObject *_histogram2d_f32(PyObject *self, PyObject *args);
+static PyObject *_histogram1d_weighted_f32(PyObject *self, PyObject *args);
+static PyObject *_histogram2d_weighted_f32(PyObject *self, PyObject *args);
 
 /* Define the methods that will be available on the module. */
 static PyMethodDef module_methods[] = {
@@ -21,6 +25,10 @@ static PyMethodDef module_methods[] = {
     {"_histogram2d", _histogram2d, METH_VARARGS, _histogram2d_docstring},
     {"_histogram1d_weighted", _histogram1d_weighted, METH_VARARGS, _histogram1d_weighted_docstring},
     {"_histogram2d_weighted", _histogram2d_weighted, METH_VARARGS, _histogram2d_weighted_docstring},
+    {"_histogram1d_f32", _histogram1d_f32, METH_VARARGS, _histogram1d_docstring},
+    {"_histogram2d_f32", _histogram2d_f32, METH_VARARGS, _histogram2d_docstring},
+    {"_histogram1d_weighted_f32", _histogram1d_weighted_f32, METH_VARARGS, _histogram1d_weighted_docstring},
+    {"_histogram2d_weighted_f32", _histogram2d_weighted_f32, METH_VARARGS, _histogram2d_weighted_docstring},
     {NULL, NULL, 0, NULL}
 };
 
@@ -55,13 +63,12 @@ MOD_INIT(_histogram_core)
 
 static PyObject *_histogram1d(PyObject *self, PyObject *args)
 {
-
     long i, n;
     int ix, nx;
-    double xmin, xmax, tx, fnx, normx;
+    npy_float64 xmin, xmax, fnx, normx;
     PyObject *x_obj, *x_array, *count_array;
     npy_intp dims[1];
-    double *x, *count;
+    npy_float64 *x, *count;
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(args, "Oidd", &x_obj, &nx, &xmin, &xmax)) {
@@ -70,7 +77,7 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args)
     }
 
     /* Interpret the input objects as `numpy` arrays. */
-    x_array = PyArray_FROM_OTF(x_obj, NPY_DOUBLE, NPY_IN_ARRAY);
+    x_array = PyArray_FROM_OTF(x_obj, NPY_FLOAT64, NPY_IN_ARRAY);
 
     /* If that didn't work, throw an `Exception`. */
     if (x_array == NULL) {
@@ -84,7 +91,7 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args)
 
     /* Build the output array */
     dims[0] = nx;
-    count_array = PyArray_SimpleNew(1, dims, NPY_DOUBLE);
+    count_array = PyArray_SimpleNew(1, dims, NPY_FLOAT64);
     if (count_array == NULL) {
         PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
         Py_DECREF(x_array);
@@ -93,25 +100,85 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args)
     }
 
     /* Releasing GIL, no allocation/referencing allowed
-     (see `ndarraytypes.h` for macros) */
+     (see `ndarrayTypes.h` for macros) */
     Py_BEGIN_ALLOW_THREADS
     PyArray_FILLWBYTE(count_array, 0);
 
-    /* Get pointers to the data as C-types. */
+    /* Get pointers to the data as C-Types. */
+    x = (npy_float64*)PyArray_DATA(x_array);
+    count = (npy_float64*)PyArray_DATA(count_array);
 
-    x = (double*)PyArray_DATA(x_array);
-    count = (double*)PyArray_DATA(count_array);
-
-    fnx = nx;
+    fnx = (npy_float64)nx;
     normx = 1. / (xmax - xmin);
 
     for(i = 0; i < n; i++) {
+        if (x[i] >= xmin && x[i] < xmax) {
+            ix = (int)((x[i] - xmin) * normx * fnx);
+            count[ix] += 1.;
+        }
+    }
+    
+    /* Clean up. */
+    Py_END_ALLOW_THREADS
+    Py_DECREF(x_array);
 
-      tx = x[i];
+    return count_array;
+}
 
-      if (tx >= xmin && tx < xmax) {
-          ix = (tx - xmin) * normx * fnx;
-          count[ix] += 1.;
+static PyObject *_histogram1d_f32(PyObject *self, PyObject *args)
+{
+    long i, n;
+    int ix, nx;
+    npy_float32 xmin, xmax, fnx, normx;
+    PyObject *x_obj, *x_array, *count_array;
+    npy_intp dims[1];
+    npy_float32 *x, *count;
+
+    /* Parse the input tuple */
+    if (!PyArg_ParseTuple(args, "Oiff", &x_obj, &nx, &xmin, &xmax)) {
+        PyErr_SetString(PyExc_TypeError, "Error parsing input");
+        return NULL;
+    }
+
+    /* Interpret the input objects as `numpy` arrays. */
+    x_array = PyArray_FROM_OTF(x_obj, NPY_FLOAT32, NPY_IN_ARRAY);
+
+    /* If that didn't work, throw an `Exception`. */
+    if (x_array == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Couldn't parse the input arrays.");
+        Py_XDECREF(x_array);
+        return NULL;
+    }
+
+    /* How many data points are there? */
+    n = (long)PyArray_DIM(x_array, 0);
+
+    /* Build the output array */
+    dims[0] = nx;
+    count_array = PyArray_SimpleNew(1, dims, NPY_FLOAT32);
+    if (count_array == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
+        Py_DECREF(x_array);
+        Py_XDECREF(count_array);
+        return NULL;
+    }
+
+    /* Releasing GIL, no allocation/referencing allowed
+     (see `ndarrayTypes.h` for macros) */
+    Py_BEGIN_ALLOW_THREADS
+    PyArray_FILLWBYTE(count_array, 0);
+
+    /* Get pointers to the data as C-Types. */
+    x = (npy_float32*)PyArray_DATA(x_array);
+    count = (npy_float32*)PyArray_DATA(count_array);
+
+    fnx = (npy_float32)nx;
+    normx = 1.f / (xmax - xmin);
+
+    for(i = 0; i < n; i++) {
+      if (x[i] >= xmin && x[i] < xmax) {
+          ix = (int)((x[i] - xmin) * normx * fnx);
+          count[ix] += 1.f;
       }
 
     }
@@ -121,19 +188,16 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args)
     Py_DECREF(x_array);
 
     return count_array;
-
 }
-
 
 static PyObject *_histogram2d(PyObject *self, PyObject *args)
 {
-
     long i, n;
     int ix, iy, nx, ny;
-    double xmin, xmax, tx, fnx, normx, ymin, ymax, ty, fny, normy;
+    npy_float64 xmin, xmax, fnx, normx, ymin, ymax, fny, normy;
     PyObject *x_obj, *y_obj, *x_array, *y_array, *count_array;
     npy_intp dims[2];
-    double *x, *y, *count;
+    npy_float64 *x, *y, *count;
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(args, "OOiddidd", &x_obj, &y_obj, &nx, &xmin, &xmax, &ny, &ymin, &ymax)) {
@@ -142,8 +206,8 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args)
     }
 
     /* Interpret the input objects as `numpy` arrays. */
-    x_array = PyArray_FROM_OTF(x_obj, NPY_DOUBLE, NPY_IN_ARRAY);
-    y_array = PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_IN_ARRAY);
+    x_array = PyArray_FROM_OTF(x_obj, NPY_FLOAT64, NPY_IN_ARRAY);
+    y_array = PyArray_FROM_OTF(y_obj, NPY_FLOAT64, NPY_IN_ARRAY);
 
     /* If that didn't work, throw an `Exception`. */
     if (x_array == NULL || y_array == NULL) {
@@ -168,7 +232,7 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args)
     dims[0] = nx;
     dims[1] = ny;
 
-    count_array = PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+    count_array = PyArray_SimpleNew(2, dims, NPY_FLOAT64);
     if (count_array == NULL) {
         PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
         Py_DECREF(x_array);
@@ -177,31 +241,26 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args)
     }
 
     /* Releasing GIL, no allocation/referencing allowed
-     (see `ndarraytypes.h` for macros) */
+     (see `ndarrayTypes.h` for macros) */
     Py_BEGIN_ALLOW_THREADS
     PyArray_FILLWBYTE(count_array, 0);
 
-    /* Get pointers to the data as C-types. */
-    x = (double*)PyArray_DATA(x_array);
-    y = (double*)PyArray_DATA(y_array);
-    count = (double*)PyArray_DATA(count_array);
+    /* Get pointers to the data as C-Types. */
+    x = (npy_float64*)PyArray_DATA(x_array);
+    y = (npy_float64*)PyArray_DATA(y_array);
+    count = (npy_float64*)PyArray_DATA(count_array);
 
-    fnx = nx;
-    fny = ny;
+    fnx = (npy_float64)nx;
+    fny = (npy_float64)ny;
     normx = 1. / (xmax - xmin);
     normy = 1. / (ymax - ymin);
 
     for(i = 0; i < n; i++) {
-
-      tx = x[i];
-      ty = y[i];
-
-      if (tx >= xmin && tx < xmax && ty >= ymin && ty < ymax) {
-          ix = (tx - xmin) * normx * fnx;
-          iy = (ty - ymin) * normy * fny;
+      if (x[i] >= xmin && x[i] < xmax && y[i] >= ymin && y[i] < ymax) {
+          ix = (int)((x[i] - xmin) * normx * fnx);
+          iy = (int)((y[i] - ymin) * normy * fny);
           count[iy + ny * ix] += 1.;
       }
-
     }
     
     /* Clean up. */
@@ -210,19 +269,98 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args)
     Py_DECREF(y_array);
 
     return count_array;
+}
 
+static PyObject *_histogram2d_f32(PyObject *self, PyObject *args)
+{
+    long i, n;
+    int ix, iy, nx, ny;
+    npy_float32 xmin, xmax, fnx, normx, ymin, ymax, fny, normy;
+    PyObject *x_obj, *y_obj, *x_array, *y_array, *count_array;
+    npy_intp dims[2];
+    npy_float32 *x, *y, *count;
+
+    /* Parse the input tuple */
+    if (!PyArg_ParseTuple(args, "OOiffiff", &x_obj, &y_obj, &nx, &xmin, &xmax, &ny, &ymin, &ymax)) {
+        PyErr_SetString(PyExc_TypeError, "Error parsing input");
+        return NULL;
+    }
+
+    /* Interpret the input objects as `numpy` arrays. */
+    x_array = PyArray_FROM_OTF(x_obj, NPY_FLOAT32, NPY_IN_ARRAY);
+    y_array = PyArray_FROM_OTF(y_obj, NPY_FLOAT32, NPY_IN_ARRAY);
+
+    /* If that didn't work, throw an `Exception`. */
+    if (x_array == NULL || y_array == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Couldn't parse the input arrays.");
+        Py_XDECREF(x_array);
+        Py_XDECREF(y_array);
+        return NULL;
+    }
+
+    /* How many data points are there? */
+    n = (long)PyArray_DIM(x_array, 0);
+
+    /* Check the dimensions. */
+    if (n != (long)PyArray_DIM(y_array, 0)) {
+        PyErr_SetString(PyExc_RuntimeError, "Dimension mismatch between x and y");
+        Py_DECREF(x_array);
+        Py_DECREF(y_array);
+        return NULL;
+    }
+
+    /* Build the output array */
+    dims[0] = nx;
+    dims[1] = ny;
+
+    count_array = PyArray_SimpleNew(2, dims, NPY_FLOAT32);
+    if (count_array == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
+        Py_DECREF(x_array);
+        Py_XDECREF(count_array);
+        return NULL;
+    }
+
+    /* Releasing GIL, no allocation/referencing allowed
+     (see `ndarrayTypes.h` for macros) */
+    Py_BEGIN_ALLOW_THREADS
+    PyArray_FILLWBYTE(count_array, 0);
+
+    /* Get pointers to the data as C-Types. */
+    x = (npy_float32*)PyArray_DATA(x_array);
+    y = (npy_float32*)PyArray_DATA(y_array);
+    count = (npy_float32*)PyArray_DATA(count_array);
+
+    fnx = (npy_float32)nx;
+    fny = (npy_float32)ny;
+    normx = 1.f / (xmax - xmin);
+    normy = 1.f / (ymax - ymin);
+
+    for(i = 0; i < n; i++) {
+      if (x[i] >= xmin && x[i] < xmax && y[i] >= ymin && y[i] < ymax) {
+          ix = (int)((x[i] - xmin) * normx * fnx);
+          iy = (int)((y[i] - ymin) * normy * fny);
+          count[iy + ny * ix] += 1.f;
+      }
+    }
+    
+    /* Clean up. */
+    Py_END_ALLOW_THREADS
+    Py_DECREF(x_array);
+    Py_DECREF(y_array);
+
+    return count_array;
 }
 
 
 static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args)
 {
-
     long i, n;
     int ix, nx;
-    double xmin, xmax, tx, fnx, normx;
+    npy_float64 xmin, xmax, fnx, normx;
     PyObject *x_obj, *x_array, *w_obj, *w_array, *count_array;
     npy_intp dims[1];
-    double *x, *w, *count;
+    npy_float64 *x, *w, *count;
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(args, "OOidd", &x_obj, &w_obj, &nx, &xmin, &xmax)) {
@@ -231,8 +369,8 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args)
     }
 
     /* Interpret the input objects as `numpy` arrays. */
-    x_array = PyArray_FROM_OTF(x_obj, NPY_DOUBLE, NPY_IN_ARRAY);
-    w_array = PyArray_FROM_OTF(w_obj, NPY_DOUBLE, NPY_IN_ARRAY);
+    x_array = PyArray_FROM_OTF(x_obj, NPY_FLOAT64, NPY_IN_ARRAY);
+    w_array = PyArray_FROM_OTF(w_obj, NPY_FLOAT64, NPY_IN_ARRAY);
 
     /* If that didn't work, throw an `Exception`. */
     if (x_array == NULL || w_array == NULL) {
@@ -255,7 +393,7 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args)
 
     /* Build the output array */
     dims[0] = nx;
-    count_array = PyArray_SimpleNew(1, dims, NPY_DOUBLE);
+    count_array = PyArray_SimpleNew(1, dims, NPY_FLOAT64);
     if (count_array == NULL) {
         PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
         Py_DECREF(x_array);
@@ -265,28 +403,24 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args)
     }
 
     /* Releasing GIL, no allocation/referencing allowed
-     (see `ndarraytypes.h` for macros) */
+     (see `ndarrayTypes.h` for macros) */
     Py_BEGIN_ALLOW_THREADS
     PyArray_FILLWBYTE(count_array, 0);
 
-    /* Get pointers to the data as C-types. */
+    /* Get pointers to the data as C-Types. */
 
-    x = (double*)PyArray_DATA(x_array);
-    w = (double*)PyArray_DATA(w_array);
-    count = (double*)PyArray_DATA(count_array);
+    x = (npy_float64*)PyArray_DATA(x_array);
+    w = (npy_float64*)PyArray_DATA(w_array);
+    count = (npy_float64*)PyArray_DATA(count_array);
 
     fnx = nx;
     normx = 1. / (xmax - xmin);
 
     for(i = 0; i < n; i++) {
-
-      tx = x[i];
-
-      if (tx >= xmin && tx < xmax) {
-          ix = (tx - xmin) * normx * fnx;
+      if (x[i] >= xmin && x[i] < xmax) {
+          ix = (int)((x[i] - xmin) * normx * fnx);
           count[ix] += w[i];
       }
-
     }
 
     /* Clean up. */
@@ -295,19 +429,94 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args)
     Py_DECREF(w_array);
 
     return count_array;
-
 }
 
+static PyObject *_histogram1d_weighted_f32(PyObject *self, PyObject *args)
+{
+    long i, n;
+    int ix, nx;
+    npy_float32 xmin, xmax, fnx, normx;
+    PyObject *x_obj, *x_array, *w_obj, *w_array, *count_array;
+    npy_intp dims[1];
+    npy_float32 *x, *w, *count;
+
+    /* Parse the input tuple */
+    if (!PyArg_ParseTuple(args, "OOiff", &x_obj, &w_obj, &nx, &xmin, &xmax)) {
+        PyErr_SetString(PyExc_TypeError, "Error parsing input");
+        return NULL;
+    }
+
+    /* Interpret the input objects as `numpy` arrays. */
+    x_array = PyArray_FROM_OTF(x_obj, NPY_FLOAT32, NPY_IN_ARRAY);
+    w_array = PyArray_FROM_OTF(w_obj, NPY_FLOAT32, NPY_IN_ARRAY);
+
+    /* If that didn't work, throw an `Exception`. */
+    if (x_array == NULL || w_array == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Couldn't parse the input arrays.");
+        Py_XDECREF(x_array);
+        Py_XDECREF(w_array);
+        return NULL;
+    }
+
+    /* How many data points are there? */
+    n = (long)PyArray_DIM(x_array, 0);
+
+    /* Check the dimensions. */
+    if (n != (long)PyArray_DIM(w_array, 0)) {
+        PyErr_SetString(PyExc_RuntimeError, "Dimension mismatch between x and w");
+        Py_DECREF(x_array);
+        Py_DECREF(w_array);
+        return NULL;
+    }
+
+    /* Build the output array */
+    dims[0] = nx;
+    count_array = PyArray_SimpleNew(1, dims, NPY_FLOAT32);
+    if (count_array == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
+        Py_DECREF(x_array);
+        Py_DECREF(w_array);
+        Py_XDECREF(count_array);
+        return NULL;
+    }
+
+    /* Releasing GIL, no allocation/referencing allowed
+     (see `ndarrayTypes.h` for macros) */
+    Py_BEGIN_ALLOW_THREADS
+    PyArray_FILLWBYTE(count_array, 0);
+
+    /* Get pointers to the data as C-Types. */
+
+    x = (npy_float32*)PyArray_DATA(x_array);
+    w = (npy_float32*)PyArray_DATA(w_array);
+    count = (npy_float32*)PyArray_DATA(count_array);
+
+    fnx = nx;
+    normx = 1. / (xmax - xmin);
+
+    for(i = 0; i < n; i++) {
+      if (x[i] >= xmin && x[i] < xmax) {
+          ix = (int)((x[i] - xmin) * normx * fnx);
+          count[ix] += w[i];
+      }
+    }
+
+    /* Clean up. */
+    Py_END_ALLOW_THREADS
+    Py_DECREF(x_array);
+    Py_DECREF(w_array);
+
+    return count_array;
+}
 
 static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args)
 {
-
     long i, n;
     int ix, iy, nx, ny;
-    double xmin, xmax, tx, fnx, normx, ymin, ymax, ty, fny, normy;
+    npy_float64 xmin, xmax, fnx, normx, ymin, ymax, fny, normy;
     PyObject *x_obj, *y_obj, *w_obj, *x_array, *y_array, *w_array, *count_array;
     npy_intp dims[2];
-    double *x, *y, *w, *count;
+    npy_float64 *x, *y, *w, *count;
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(args, "OOOiddidd", &x_obj, &y_obj, &w_obj, &nx, &xmin, &xmax, &ny, &ymin, &ymax)) {
@@ -316,9 +525,9 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args)
     }
 
     /* Interpret the input objects as `numpy` arrays. */
-    x_array = PyArray_FROM_OTF(x_obj, NPY_DOUBLE, NPY_IN_ARRAY);
-    y_array = PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_IN_ARRAY);
-    w_array = PyArray_FROM_OTF(w_obj, NPY_DOUBLE, NPY_IN_ARRAY);
+    x_array = PyArray_FROM_OTF(x_obj, NPY_FLOAT64, NPY_IN_ARRAY);
+    y_array = PyArray_FROM_OTF(y_obj, NPY_FLOAT64, NPY_IN_ARRAY);
+    w_array = PyArray_FROM_OTF(w_obj, NPY_FLOAT64, NPY_IN_ARRAY);
 
     /* If that didn't work, throw an `Exception`. */
     if (x_array == NULL || y_array == NULL || w_array == NULL) {
@@ -345,7 +554,7 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args)
     dims[0] = nx;
     dims[1] = ny;
 
-    count_array = PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+    count_array = PyArray_SimpleNew(2, dims, NPY_FLOAT64);
     if (count_array == NULL) {
         PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
         Py_DECREF(x_array);
@@ -354,32 +563,27 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args)
     }
 
     /* Releasing GIL, no allocation/referencing allowed
-     (see `ndarraytypes.h` for macros) */
+     (see `ndarrayTypes.h` for macros) */
     Py_BEGIN_ALLOW_THREADS
     PyArray_FILLWBYTE(count_array, 0);
 
-    /* Get pointers to the data as C-types. */
-    x = (double*)PyArray_DATA(x_array);
-    y = (double*)PyArray_DATA(y_array);
-    w = (double*)PyArray_DATA(w_array);
-    count = (double*)PyArray_DATA(count_array);
+    /* Get pointers to the data as C-Types. */
+    x = (npy_float64*)PyArray_DATA(x_array);
+    y = (npy_float64*)PyArray_DATA(y_array);
+    w = (npy_float64*)PyArray_DATA(w_array);
+    count = (npy_float64*)PyArray_DATA(count_array);
 
-    fnx = nx;
-    fny = ny;
+    fnx = (npy_float64)nx;
+    fny = (npy_float64)ny;
     normx = 1. / (xmax - xmin);
     normy = 1. / (ymax - ymin);
 
     for(i = 0; i < n; i++) {
-
-      tx = x[i];
-      ty = y[i];
-
-      if (tx >= xmin && tx < xmax && ty >= ymin && ty < ymax) {
-          ix = (tx - xmin) * normx * fnx;
-          iy = (ty - ymin) * normy * fny;
-          count[iy + ny * ix] += w[i];
-      }
-
+        if (x[i] >= xmin && x[i] < xmax && y[i] >= ymin && y[i] < ymax) {
+            ix = (int)((x[i] - xmin) * normx * fnx);
+            iy = (int)((y[i] - ymin) * normy * fny);
+            count[iy + ny * ix] += w[i];
+        }
     }
 
     /* Clean up. */
@@ -389,5 +593,90 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args)
     Py_DECREF(w_array);
 
     return count_array;
+}
 
+static PyObject *_histogram2d_weighted_f32(PyObject *self, PyObject *args)
+{
+    long i, n;
+    int ix, iy, nx, ny;
+    npy_float32 xmin, xmax, fnx, normx, ymin, ymax, fny, normy;
+    PyObject *x_obj, *y_obj, *w_obj, *x_array, *y_array, *w_array, *count_array;
+    npy_intp dims[2];
+    npy_float32 *x, *y, *w, *count;
+
+    /* Parse the input tuple */
+    if (!PyArg_ParseTuple(args, "OOOiffiff", &x_obj, &y_obj, &w_obj, &nx, &xmin, &xmax, &ny, &ymin, &ymax)) {
+        PyErr_SetString(PyExc_TypeError, "Error parsing input");
+        return NULL;
+    }
+
+    /* Interpret the input objects as `numpy` arrays. */
+    x_array = PyArray_FROM_OTF(x_obj, NPY_FLOAT32, NPY_IN_ARRAY);
+    y_array = PyArray_FROM_OTF(y_obj, NPY_FLOAT32, NPY_IN_ARRAY);
+    w_array = PyArray_FROM_OTF(w_obj, NPY_FLOAT32, NPY_IN_ARRAY);
+
+    /* If that didn't work, throw an `Exception`. */
+    if (x_array == NULL || y_array == NULL || w_array == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Couldn't parse the input arrays.");
+        Py_XDECREF(x_array);
+        Py_XDECREF(y_array);
+        Py_XDECREF(w_array);
+        return NULL;
+    }
+
+    /* How many data points are there? */
+    n = (long)PyArray_DIM(x_array, 0);
+
+    /* Check the dimensions. */
+    if (n != (long)PyArray_DIM(y_array, 0) || n != (long)PyArray_DIM(w_array, 0)) {
+        PyErr_SetString(PyExc_RuntimeError, "Dimension mismatch between x, y, and w");
+        Py_DECREF(x_array);
+        Py_DECREF(y_array);
+        Py_DECREF(w_array);
+        return NULL;
+    }
+
+    /* Build the output array */
+    dims[0] = nx;
+    dims[1] = ny;
+
+    count_array = PyArray_SimpleNew(2, dims, NPY_FLOAT32);
+    if (count_array == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
+        Py_DECREF(x_array);
+        Py_XDECREF(count_array);
+        return NULL;
+    }
+
+    /* Releasing GIL, no allocation/referencing allowed
+     (see `ndarrayTypes.h` for macros) */
+    Py_BEGIN_ALLOW_THREADS
+    PyArray_FILLWBYTE(count_array, 0);
+
+    /* Get pointers to the data as C-Types. */
+    x = (npy_float32*)PyArray_DATA(x_array);
+    y = (npy_float32*)PyArray_DATA(y_array);
+    w = (npy_float32*)PyArray_DATA(w_array);
+    count = (npy_float32*)PyArray_DATA(count_array);
+
+    fnx = (npy_float32)nx;
+    fny = (npy_float32)ny;
+    normx = 1. / (xmax - xmin);
+    normy = 1. / (ymax - ymin);
+
+    for(i = 0; i < n; i++) {
+        if (x[i] >= xmin && x[i] < xmax && y[i] >= ymin && y[i] < ymax) {
+            ix = (int)((x[i] - xmin) * normx * fnx);
+            iy = (int)((y[i] - ymin) * normy * fny);
+            count[iy + ny * ix] += w[i];
+        }
+    }
+
+    /* Clean up. */
+    Py_END_ALLOW_THREADS
+    Py_DECREF(x_array);
+    Py_DECREF(y_array);
+    Py_DECREF(w_array);
+
+    return count_array;
 }

--- a/fast_histogram/histogram.py
+++ b/fast_histogram/histogram.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 import numbers
-
+from time import perf_counter
 import numpy as np
 
 from ._histogram_core import (_histogram1d,
@@ -10,6 +10,20 @@ from ._histogram_core import (_histogram1d,
                               _histogram2d_weighted)
 
 __all__ = ['histogram1d', 'histogram2d']
+
+_cast_to = {
+    np.dtype('float64'): None,
+    np.dtype('float32'): None,
+    np.dtype('bool'):    np.dtype('float32'),
+    np.dtype('uint8'):   np.dtype('float32'),
+    np.dtype('int8'):    np.dtype('float32'),
+    np.dtype('uint16'):  np.dtype('float32'),
+    np.dtype('int16'):   np.dtype('float32'),
+    np.dtype('uint32'):  np.dtype('float64'),
+    np.dtype('int32'):   np.dtype('float64'),
+    np.dtype('uint64'):  np.dtype('float64'),
+    np.dtype('int64'):   np.dtype('float64'),
+}
 
 
 def histogram1d(x, bins, range, weights=None):
@@ -32,7 +46,6 @@ def histogram1d(x, bins, range, weights=None):
     array : `~numpy.ndarray`
         The 1D histogram array
     """
-
     nx = bins
     xmin, xmax = range
 
@@ -48,13 +61,21 @@ def histogram1d(x, bins, range, weights=None):
     if nx <= 0:
         raise ValueError("nx should be strictly positive")
 
-    x = np.ascontiguousarray(x, np.float)
+    castType = _cast_to[x.dtype]
+    if not x.flags.c_contiguous:
+        x = np.ascontiguousarray(x, castType)
+    elif castType:
+        x = x.astype(castType)
 
     if weights is None:
         return _histogram1d(x, nx, xmin, xmax)
-    else:
-        weights = np.ascontiguousarray(weights, np.float)
-        return _histogram1d_weighted(x, weights, nx, xmin, xmax)
+
+     # Else weighted histogram
+    if not weights.flags.c_contiguous:
+        weights = np.ascontiguousarray(weights, castType)
+    elif castType:
+        weights = weights.astype(castType)
+    return _histogram1d_weighted(x, weights, nx, xmin, xmax)
 
 
 def histogram2d(x, y, bins, range, weights=None):
@@ -111,11 +132,27 @@ def histogram2d(x, y, bins, range, weights=None):
     if ny <= 0:
         raise ValueError("ny should be strictly positive")
 
-    x = np.ascontiguousarray(x, np.float)
-    y = np.ascontiguousarray(y, np.float)
+    castXType = _cast_to[x.dtype]
+    castYType = _cast_to[y.dtype]
+    castType = np.dtype('f'%np.maximum(castXType.itemsize, castYType.itemsize))
+
+    if not x.flags.c_contiguous:
+        x = np.ascontiguousarray(x, castXType)
+    elif castXType != castType:
+        x = x.astype(castXType)
+    
+    if not y.flags.c_contiguous:
+        y = np.ascontiguousarray(y, castYType)
+    elif castYType != castType:
+        y = y.astype(castYType)
 
     if weights is None:
         return _histogram2d(x, y, nx, xmin, xmax, ny, ymin, ymax)
-    else:
-        weights = np.ascontiguousarray(weights, np.float)
-        return _histogram2d_weighted(x, y, weights, nx, xmin, xmax, ny, ymin, ymax)
+
+    # Else weighted histogram
+    if not weights.flags.c_contiguous:
+        weights = np.ascontiguousarray(weights, castXType)
+    elif weights.dtype != castType:
+        weights = weights.astype(castXType)
+
+    return _histogram2d_weighted(x, y, weights, nx, xmin, xmax, ny, ymin, ymax)

--- a/fast_histogram/histogram.py
+++ b/fast_histogram/histogram.py
@@ -1,7 +1,6 @@
 from __future__ import division
 
 import numbers
-from time import perf_counter
 import numpy as np
 
 from ._histogram_core import (_histogram1d,
@@ -14,15 +13,15 @@ __all__ = ['histogram1d', 'histogram2d']
 _cast_to = {
     np.dtype('float64'): None,
     np.dtype('float32'): None,
-    np.dtype('bool'):    np.dtype('float32'),
-    np.dtype('uint8'):   np.dtype('float32'),
-    np.dtype('int8'):    np.dtype('float32'),
-    np.dtype('uint16'):  np.dtype('float32'),
-    np.dtype('int16'):   np.dtype('float32'),
-    np.dtype('uint32'):  np.dtype('float64'),
-    np.dtype('int32'):   np.dtype('float64'),
-    np.dtype('uint64'):  np.dtype('float64'),
-    np.dtype('int64'):   np.dtype('float64'),
+    np.dtype('bool')   : np.dtype('float32'),
+    np.dtype('uint8')  : np.dtype('float32'),
+    np.dtype('int8')   : np.dtype('float32'),
+    np.dtype('uint16') : np.dtype('float32'),
+    np.dtype('int16')  : np.dtype('float32'),
+    np.dtype('uint32') : np.dtype('float64'),
+    np.dtype('int32')  : np.dtype('float64'),
+    np.dtype('uint64') : np.dtype('float64'),
+    np.dtype('int64')  : np.dtype('float64')
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,20 @@ import numpy as np
 from setuptools import setup
 from setuptools.extension import Extension
 
+
+# MSVC vectorization report: '/Qvec-report:2'
+# GCC vectorization report: '-fopt-info-vec', '-fopt-info-vec-missed', '-fdiagnostics-color=always'
+if os.name == 'nt':
+      extra_compile_args = ['/Qvec-report:2']
+else:
+      extra_compile_args = ['-fopt-info-vec', '-fopt-info-vec-missed', '-fdiagnostics-color=always']
+
 extensions = [Extension("fast_histogram._histogram_core",
                        [os.path.join('fast_histogram', '_histogram_core.c')],
-                       include_dirs=[np.get_include()])]
+                       include_dirs=[np.get_include()],
+                       extra_compile_args=extra_compile_args
+                       )]
+
 
 setup(name='fast-histogram',
       version='0.4.dev0',


### PR DESCRIPTION
* Adds `npy_float32` functions. Casting determination done by a casting dictionary, `fast_histogram._cast_to`  which mimics `numpy.histogram`.
* Releases the GIL in pure-C operation, although this does not appear to beneficially impact performance.

Sorry for the autistic changing of `double` -> `npy_float64`.  I can revert that if you want.