### PR TITLE
Cast to double on-the-fly

### DIFF
--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -90,7 +90,7 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args) {
   dims[0] = nx;
   count_array = PyArray_SimpleNew(1, dims, NPY_DOUBLE);
   if (count_array == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't build output array");
     Py_DECREF(x_array);
     Py_XDECREF(count_array);
     return NULL;
@@ -120,7 +120,7 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args) {
    */
   iternext = NpyIter_GetIterNext(iter, NULL);
   if (iternext == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Couldn't set up iterator");
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
     NpyIter_Deallocate(iter);
     Py_DECREF(x_array);
     Py_XDECREF(count_array);
@@ -222,7 +222,7 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
   dims[1] = ny;
   count_array = PyArray_SimpleNew(2, dims, NPY_DOUBLE);
   if (count_array == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't build output array");
     Py_DECREF(x_array);
     Py_DECREF(y_array);
     Py_XDECREF(count_array);
@@ -365,7 +365,7 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args) {
   dims[0] = nx;
   count_array = PyArray_SimpleNew(1, dims, NPY_DOUBLE);
   if (count_array == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't build output array");
     Py_DECREF(x_array);
     Py_DECREF(w_array);
     Py_XDECREF(count_array);
@@ -509,7 +509,7 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args) {
   dims[1] = ny;
   count_array = PyArray_SimpleNew(2, dims, NPY_DOUBLE);
   if (count_array == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Couldn't build output array");
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't build output array");
     Py_DECREF(x_array);
     Py_DECREF(y_array);
     Py_DECREF(w_array);

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -128,7 +128,7 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args) {
   }
 
   /* The location of the data pointer which the iterator may update */
-  dataptr = (char **)NpyIter_GetDataPtrArray(iter);
+  dataptr = NpyIter_GetDataPtrArray(iter);
 
   /* The location of the stride which the iterator may update */
   strideptr = NpyIter_GetInnerStrideArray(iter);
@@ -178,7 +178,7 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
   int ix, iy, nx, ny;
   double xmin, xmax, tx, fnx, normx, ymin, ymax, ty, fny, normy;
   PyObject *x_obj, *y_obj, *count_array;
-  PyArrayObject *x_array, *y_array;
+  PyArrayObject *x_array, *y_array, *arrays[2];
   npy_intp dims[2];
   double *count;
   NpyIter *iter;
@@ -237,8 +237,9 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
     return count_array;
   }
 
-  PyArrayObject *op[] = {x_array, y_array};
-  iter = NpyIter_AdvancedNew(2, op,
+  arrays[0] = x_array;
+  arrays[1] = y_array;
+  iter = NpyIter_AdvancedNew(2, arrays,
                              NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
                              NPY_KEEPORDER, NPY_SAFE_CASTING, op_flags, dtypes,
                              -1, NULL, NULL, 0);
@@ -265,7 +266,7 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
   }
 
   /* The location of the data pointer which the iterator may update */
-  dataptr = (char **)NpyIter_GetDataPtrArray(iter);
+  dataptr = NpyIter_GetDataPtrArray(iter);
 
   /* The location of the stride which the iterator may update */
   strideptr = NpyIter_GetInnerStrideArray(iter);
@@ -321,7 +322,7 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args) {
   int ix, nx;
   double xmin, xmax, tx, tw, fnx, normx;
   PyObject *x_obj, *w_obj, *count_array;
-  PyArrayObject *x_array, *w_array;
+  PyArrayObject *x_array, *w_array, *arrays[2];
   npy_intp dims[1];
   double *count;
   NpyIter *iter;
@@ -379,8 +380,9 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args) {
     return count_array;
   }
 
-  PyArrayObject *op[] = {x_array, w_array};
-  iter = NpyIter_AdvancedNew(2, op,
+  arrays[0] = x_array;
+  arrays[1] = w_array;
+  iter = NpyIter_AdvancedNew(2, arrays,
                              NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
                              NPY_KEEPORDER, NPY_SAFE_CASTING, op_flags, dtypes,
                              -1, NULL, NULL, 0);
@@ -407,7 +409,7 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args) {
   }
 
   /* The location of the data pointer which the iterator may update */
-  dataptr = (char **)NpyIter_GetDataPtrArray(iter);
+  dataptr = NpyIter_GetDataPtrArray(iter);
 
   /* The location of the stride which the iterator may update */
   strideptr = NpyIter_GetInnerStrideArray(iter);
@@ -460,7 +462,7 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args) {
   int ix, iy, nx, ny;
   double xmin, xmax, tx, fnx, normx, ymin, ymax, ty, fny, normy, tw;
   PyObject *x_obj, *y_obj, *w_obj, *count_array;
-  PyArrayObject *x_array, *y_array, *w_array;
+  PyArrayObject *x_array, *y_array, *w_array, *arrays[3];
   npy_intp dims[2];
   double *count;
   NpyIter *iter;
@@ -524,8 +526,10 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args) {
     return count_array;
   }
 
-  PyArrayObject *op[] = {x_array, y_array, w_array};
-  iter = NpyIter_AdvancedNew(3, op,
+  arrays[0] = x_array;
+  arrays[1] = y_array;
+  arrays[2] = w_array;
+  iter = NpyIter_AdvancedNew(3, arrays,
                              NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
                              NPY_KEEPORDER, NPY_SAFE_CASTING, op_flags, dtypes,
                              -1, NULL, NULL, 0);
@@ -554,7 +558,7 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args) {
   }
 
   /* The location of the data pointer which the iterator may update */
-  dataptr = (char **)NpyIter_GetDataPtrArray(iter);
+  dataptr = NpyIter_GetDataPtrArray(iter);
 
   /* The location of the stride which the iterator may update */
   strideptr = NpyIter_GetInnerStrideArray(iter);

--- a/fast_histogram/histogram.py
+++ b/fast_histogram/histogram.py
@@ -12,16 +12,6 @@ from ._histogram_core import (_histogram1d,
 __all__ = ['histogram1d', 'histogram2d']
 
 
-def byteswap_if_needed(array):
-    if (isinstance(array, np.ndarray) and array.dtype.kind == 'f'
-            and array.dtype.itemsize == 8 and array.flags.c_contiguous):
-        byteswap = int(not array.dtype.isnative)
-    else:
-        array = np.ascontiguousarray(array, np.float)
-        byteswap = 0
-    return array, byteswap
-
-
 def histogram1d(x, bins, range, weights=None):
     """
     Compute a 1D histogram assuming equally spaced bins.
@@ -58,19 +48,10 @@ def histogram1d(x, bins, range, weights=None):
     if nx <= 0:
         raise ValueError("nx should be strictly positive")
 
-    x, xbyteswap = byteswap_if_needed(x)
-
-    if x.ndim > 1:
-        x = x.ravel()
-
-    if x.size == 0:
-        return np.zeros(nx)
-
     if weights is None:
-        return _histogram1d(x, nx, xmin, xmax, xbyteswap)
+        return _histogram1d(x, nx, xmin, xmax)
     else:
-        weights, wbyteswap = byteswap_if_needed(weights)
-        return _histogram1d_weighted(x, weights, nx, xmin, xmax, xbyteswap, wbyteswap)
+        return _histogram1d_weighted(x, weights, nx, xmin, xmax)
 
 
 def histogram2d(x, y, bins, range, weights=None):
@@ -127,17 +108,7 @@ def histogram2d(x, y, bins, range, weights=None):
     if ny <= 0:
         raise ValueError("ny should be strictly positive")
 
-    x, xbyteswap = byteswap_if_needed(x)
-    y, ybyteswap = byteswap_if_needed(y)
-
-    if x.ndim > 1:
-        x = x.ravel()
-
-    if y.ndim > 1:
-        y = y.ravel()
-
     if weights is None:
-        return _histogram2d(x, y, nx, xmin, xmax, ny, ymin, ymax, xbyteswap, ybyteswap)
+        return _histogram2d(x, y, nx, xmin, xmax, ny, ymin, ymax)
     else:
-        weights, wbyteswap = byteswap_if_needed(weights)
-        return _histogram2d_weighted(x, y, weights, nx, xmin, xmax, ny, ymin, ymax, xbyteswap, ybyteswap, wbyteswap)
+        return _histogram2d_weighted(x, y, weights, nx, xmin, xmax, ny, ymin, ymax)


### PR DESCRIPTION
*This is an alternative to https://github.com/astrofrog/fast-histogram/pull/19*

Previously, any array that was not of native double type and contiguous was copied in memory, leading to performance issues. This PR switches the C code to use the Numpy C API to iterate over the array. This does not appear to have a significant performance impact and has the following benefits:

* The input arrays can now be of any data type that can be converted to doubles, and the types of the different arrays passed to the histogram functions don't have to match (unlike a solution like https://github.com/astrofrog/fast-histogram/pull/19)

* The casting is done using chunks of length 8192, which means that there is no significant memory increase due to the casting

* Non-contiguous arrays can now be passed

* N-dimensional arrays and list types are automatically dealt with