### PR TITLE
Make sure that Numpy doesn't get installed during egg_info phase of pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.rst
 include CHANGES.rst
+include pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,12 @@ import io
 # rather than pip, and this can mean picking up pre-releases. See
 # https://mail.python.org/pipermail/numpy-discussion/2019-January/079097.html
 # for more details.
-import numpy
+try:
+    import numpy
+except ImportError:
+    raise ImportError("Numpy is required to install this package - either "
+                      "install it first or update to pip 10.0 or later for it "
+                      "to be automatically installed")
 
 from setuptools import setup
 from setuptools.extension import Extension

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
 import os
 import io
 
+# Note that numpy is included as a build-time dependency in pyproject.toml as
+# described in PEP 518. This works with pip 10.x and later. For older version
+# of pip, one could in principle use setup_requires=['numpy'] in the setup call
+# below but this can cause issues since setup_requires is honored by easy_install
+# rather than pip, and this can mean picking up pre-releases. See
+# https://mail.python.org/pipermail/numpy-discussion/2019-January/079097.html
+# for more details.
+import numpy
+
 from setuptools import setup
 from setuptools.extension import Extension
-from setuptools.command.build_ext import build_ext
-
-
-class build_ext_with_numpy(build_ext):
-    def finalize_options(self):
-        build_ext.finalize_options(self)
-        import numpy
-        self.include_dirs.append(numpy.get_include())
-
 
 extensions = [Extension("fast_histogram._histogram_core",
-                        [os.path.join('fast_histogram', '_histogram_core.c')])]
+                        [os.path.join('fast_histogram', '_histogram_core.c')],
+                        include_dirs=[numpy.get_include()])]
 
 with io.open('README.rst', encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
@@ -23,12 +24,10 @@ setup(name='fast-histogram',
       version='0.6.dev0',
       description='Fast simple 1D and 2D histograms',
       long_description=LONG_DESCRIPTION,
-      setup_requires=['numpy'],
       install_requires=['numpy'],
       author='Thomas Robitaille',
       author_email='thomas.robitaille@gmail.com',
       license='BSD',
       url='https://github.com/astrofrog/fast-histogram',
       packages=['fast_histogram', 'fast_histogram.tests'],
-      ext_modules=extensions,
-      cmdclass={'build_ext': build_ext_with_numpy})
+      ext_modules=extensions)


### PR DESCRIPTION
Currently numpy was downloaded and build from source during the egg_info phase which caused issues on certain platforms.