### PR TITLE
Fixes related to Numpy as a build-time requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,8 @@ jobs:
       - run:
           name: Test install with pre-existing Numpy
           command: |
-            virtualenv default
-            source default/bin/activate
+            virtualenv pre
+            source pre/bin/activate
             pip3 install numpy==1.12.1
             pip3 install .
             cd tmp
@@ -58,8 +58,8 @@ jobs:
       - run:
           name: Test install with pinned Numpy
           command: |
-            virtualenv default
-            source default/bin/activate
+            virtualenv pinned
+            source pinned/bin/activate
             pip3 install . numpy==1.12.1
             cd tmp
             python3 -c 'import fast_histogram'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,12 +34,17 @@ jobs:
           name: Install virtualenv
           command: pip3 install virtualenv
       - run:
+          name: Make temporary directory for testing imports
+          command: mkdir tmp
+      - run:
           name: Test default install
           command: |
             virtualenv default
             source default/bin/activate
             pip3 install .
+            cd tmp
             python3 -c 'import fast_histogram'
+            cd ..
       - run:
           name: Test install with pre-existing Numpy
           command: |
@@ -47,14 +52,18 @@ jobs:
             source default/bin/activate
             pip3 install numpy==1.12.1
             pip3 install .
+            cd tmp
             python3 -c 'import fast_histogram'
+            cd ..
       - run:
           name: Test install with pinned Numpy
           command: |
             virtualenv default
             source default/bin/activate
             pip3 install . numpy==1.12.1
+            cd tmp
             python3 -c 'import fast_histogram'
+            cd ..
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,9 @@
 version: 2
 
 jobs:
-  build:
+
+  # Run the tests with 32-bit Python
+  32bit:
     docker:
       - image: quay.io/pypa/manylinux1_i686
     steps:
@@ -15,3 +17,48 @@ jobs:
       - run:
           name: Run tests
           command: /opt/python/cp36-cp36m/bin/pytest fast_histogram -p no:warnings --hypothesis-show-statistics
+
+  # The following tests are to make sure that we deal correctly with numpy
+  # as a build requirement.
+  numpy:
+    docker:
+      - image: ubuntu:16.04
+    steps:
+      - checkout
+      - run:
+          name: Install Python
+          command: |
+            apt-get update
+            apt-get install -y python3 python3-dev python3-pip python3-wheel
+      - run:
+          name: Install virtualenv
+          command: pip3 install virtualenv
+      - run:
+          name: Test default install
+          command: |
+            virtualenv default
+            source default/bin/activate
+            pip3 install .
+            python3 -c 'import fast_histogram'
+      - run:
+          name: Test install with pre-existing Numpy
+          command: |
+            virtualenv default
+            source default/bin/activate
+            pip3 install numpy==1.12.1
+            pip3 install .
+            python3 -c 'import fast_histogram'
+      - run:
+          name: Test install with pinned Numpy
+          command: |
+            virtualenv default
+            source default/bin/activate
+            pip3 install . numpy==1.12.1
+            python3 -c 'import fast_histogram'
+
+workflows:
+  version: 2
+  tests_and_docs:
+    jobs:
+      - 32bit
+      - numpy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,15 +55,17 @@ jobs:
             cd tmp
             python3 -c 'import fast_histogram'
             cd ..
-      - run:
-          name: Test install with pinned Numpy
-          command: |
-            virtualenv pinned
-            source pinned/bin/activate
-            pip3 install . numpy==1.12.1
-            cd tmp
-            python3 -c 'import fast_histogram'
-            cd ..
+      # The following doesn't work, but could work one day when we implement
+      # pyproject.toml with the oldest numpy version for each Python version.
+      # - run:
+      #     name: Test install with pinned Numpy
+      #     command: |
+      #       virtualenv pinned
+      #       source pinned/bin/activate
+      #       pip3 install . numpy==1.12.1
+      #       cd tmp
+      #       python3 -c 'import fast_histogram'
+      #       cd ..
 
 workflows:
   version: 2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include LICENSE
 include README.rst
 include CHANGES.rst
-include pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[build-system]
-requires = ["setuptools", "wheel", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -1,38 +1,47 @@
 import os
 import io
-
-# Note that numpy is included as a build-time dependency in pyproject.toml as
-# described in PEP 518. This works with pip 10.x and later. For older version
-# of pip, one could in principle use setup_requires=['numpy'] in the setup call
-# below but this can cause issues since setup_requires is honored by easy_install
-# rather than pip, and this can mean picking up pre-releases. See
-# https://mail.python.org/pipermail/numpy-discussion/2019-January/079097.html
-# for more details.
-try:
-    import numpy
-except ImportError:
-    raise ImportError("Numpy is required to install this package - either "
-                      "install it first or update to pip 10.0 or later for it "
-                      "to be automatically installed")
+import sys
 
 from setuptools import setup
 from setuptools.extension import Extension
+from setuptools.command.build_ext import build_ext
+
+
+class build_ext_with_numpy(build_ext):
+    def run(self):
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+        build_ext.run(self)
+
 
 extensions = [Extension("fast_histogram._histogram_core",
-                        [os.path.join('fast_histogram', '_histogram_core.c')],
-                        include_dirs=[numpy.get_include()])]
+                        [os.path.join('fast_histogram', '_histogram_core.c')])]
 
 with io.open('README.rst', encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
+
+try:
+    import numpy
+except ImportError:
+    # We include an upper limit to the version because setup_requires is
+    # honored by easy_install not pip, and the former doesn't ignore pre-
+    # releases. It's not an issue if the package is built against 1.15 and
+    # then 1.16 gets installed after, but it still makes sense to update the
+    # upper limit whenever a new version of Numpy is released.
+    setup_requires = ['numpy<1.16']
+else:
+    setup_requires = []
 
 setup(name='fast-histogram',
       version='0.7.dev0',
       description='Fast simple 1D and 2D histograms',
       long_description=LONG_DESCRIPTION,
+      setup_requires=setup_requires ,
       install_requires=['numpy'],
       author='Thomas Robitaille',
       author_email='thomas.robitaille@gmail.com',
       license='BSD',
       url='https://github.com/astrofrog/fast-histogram',
       packages=['fast_histogram', 'fast_histogram.tests'],
-      ext_modules=extensions)
+      ext_modules=extensions,
+      cmdclass={'build_ext': build_ext_with_numpy})


### PR DESCRIPTION
We can't yet use pyproject.toml as discussed in https://github.com/astrofrog/fast-histogram/issues/35 as we should pin numpy to the oldest supported version for each Python version. So instead this improves the setup_requires implementation and includes some new tests to make sure things work fine.