### PR TITLE
Add N-dimensional histogramming

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.10 (unreleased)
 -----------------
 
-- No changes yet.
+- Add function for histograms in arbitrarily high dimensions.
 
 0.9 (2020-05-24)
 ----------------

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -8,12 +8,14 @@
 static char module_docstring[] = "Fast histogram functioins";
 static char _histogram1d_docstring[] = "Compute a 1D histogram";
 static char _histogram2d_docstring[] = "Compute a 2D histogram";
+static char _histogramdd_docstring[] = "Compute a histogram with arbitrary dimensionality.";
 static char _histogram1d_weighted_docstring[] = "Compute a weighted 1D histogram";
 static char _histogram2d_weighted_docstring[] = "Compute a weighted 2D histogram";
 
 /* Declare the C functions here. */
 static PyObject *_histogram1d(PyObject *self, PyObject *args);
 static PyObject *_histogram2d(PyObject *self, PyObject *args);
+static PyObject *_histogramdd(PyObject *self, PyObject *args);
 static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args);
 static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args);
 
@@ -21,6 +23,7 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args);
 static PyMethodDef module_methods[] = {
     {"_histogram1d", _histogram1d, METH_VARARGS, _histogram1d_docstring},
     {"_histogram2d", _histogram2d, METH_VARARGS, _histogram2d_docstring},
+    {"_histogramdd", _histogramdd, METH_VARARGS, _histogramdd_docstring},
     {"_histogram1d_weighted", _histogram1d_weighted, METH_VARARGS, _histogram1d_weighted_docstring},
     {"_histogram2d_weighted", _histogram2d_weighted, METH_VARARGS, _histogram2d_weighted_docstring},
     {NULL, NULL, 0, NULL}
@@ -332,6 +335,261 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
   Py_DECREF(x_array);
   Py_DECREF(y_array);
 
+  return count_obj;
+}
+
+
+static PyObject *_histogramdd(PyObject *self, PyObject *args) {
+
+  long n;
+  int ndim;
+  PyObject *sample_obj, *range_obj, *bins_obj,  *count_obj;
+  PyArrayObject **arrays, *range, *bins, *count_array;
+  npy_intp *dims;
+  double *count, *range_c, *fndim, *norms;
+  double tx;
+  int idx, bin_idx, local_bin_idx, in_range, multiplier;
+  // using xmin and xmax for all dimensions
+  double xmin, xmax;
+  NpyIter *iter;
+  NpyIter_IterNextFunc *iternext;
+  char **dataptr;
+  npy_intp *strideptr, *innersizeptr;
+  PyArray_Descr *dtype;
+  PyArray_Descr **dtypes;
+  npy_uint32 *op_flags;
+
+  /* Parse the input tuple */
+  if (!PyArg_ParseTuple(args, "OOO", &sample_obj, &bins_obj, &range_obj)) {
+    PyErr_SetString(PyExc_TypeError, "Error parsing input");
+    return NULL;
+  }
+  
+  ndim = (int)PyTuple_GET_SIZE(sample_obj);
+  
+  /* Interpret the input objects as `numpy` arrays. */
+  arrays = (PyArrayObject **)malloc(sizeof(PyArrayObject *) * ndim);
+  for (int i = 0; i < ndim; i++){
+    arrays[i] = (PyArrayObject *)PyArray_FROM_O(PyTuple_GetItem(sample_obj, i));
+  }
+  
+  range = (PyArrayObject *)PyArray_FROM_O(range_obj);
+  dtype = PyArray_DescrFromType(NPY_INTP);
+  bins = (PyArrayObject *)PyArray_FROM_O(bins_obj);
+  //bins = (PyArrayObject *)PyArray_FromAny(bins_obj, dtype, 1, 1, NPY_ARRAY_IN_ARRAY, NULL);
+  
+  /* If that didn't work, throw an `Exception`. */
+  if (range == NULL || bins == NULL) {
+    PyErr_SetString(PyExc_TypeError, "Couldn't parse the input arrays. Note that bins must be given as np.intp type.");
+    for (int i = 0; i < ndim; i++){
+      Py_XDECREF(arrays[i]);
+    }
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
+    return NULL;
+  }
+  
+  /* How many data points are there? */
+  n = (long)PyArray_DIM(arrays[0], 0);
+  
+  /* copy the content of `bins` into `dims` */
+  dtype = PyArray_DescrFromType(NPY_INTP);
+  iter = NpyIter_New(bins, NPY_ITER_READONLY, NPY_CORDER, NPY_SAFE_CASTING, dtype);
+  if (iter == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator over binning.");
+    for (int i = 0; i < ndim; i++){
+      Py_XDECREF(arrays[i]);
+    }
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
+    return NULL;
+  }
+  iternext = NpyIter_GetIterNext(iter, NULL);
+  if (iternext == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iteration function over binning.");
+    for (int i = 0; i < ndim; i++){
+      Py_XDECREF(arrays[i]);
+    }
+    NpyIter_Deallocate(iter);
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
+    return NULL;
+  }
+  dataptr = NpyIter_GetDataPtrArray(iter);
+  dims = (npy_intp *)malloc(sizeof(npy_intp) * ndim);
+  int i = 0;
+  do{
+    dims[i] = *(npy_intp *)dataptr[0];
+    i++;
+  } while (iternext(iter));
+  NpyIter_Deallocate(iter);
+  
+  /* build the output array */
+  count_obj = PyArray_SimpleNew(ndim, dims, NPY_DOUBLE);
+  if (count_obj == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't build output array");
+    for (int i = 0; i < ndim; i++){
+      Py_XDECREF(arrays[i]);
+    }
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
+    Py_XDECREF(count_obj);
+    return NULL;
+  }
+
+  count_array = (PyArrayObject *)count_obj;
+
+  PyArray_FILLWBYTE(count_array, 0);
+  
+  if (n == 0) {
+    for (int i = 0; i < ndim; i++){
+      Py_XDECREF(arrays[i]);
+    }
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
+    return count_obj;
+  }
+
+  /* copy the content of the numpy array `ranges` into a simple C array */
+  // This just makes is easier to access the values later in the loop. 
+  range_c = (double *)malloc(sizeof(double) * ndim * 2);
+  dtype = PyArray_DescrFromType(NPY_DOUBLE);
+  iter = NpyIter_New(range, NPY_ITER_READONLY, NPY_CORDER, NPY_SAFE_CASTING, dtype);
+  if (iter == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator over range. This needs to be passed as type `numpy.double`.");
+    for (int i = 0; i < ndim; i++){
+      Py_XDECREF(arrays[i]);
+    }
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
+    Py_DECREF(count_obj);
+    return NULL;
+  }
+  iternext = NpyIter_GetIterNext(iter, NULL);
+  if (iternext == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iteration function over range. This needs to be passed as type `numpy.double`.");
+    NpyIter_Deallocate(iter);
+    for (int i = 0; i < ndim; i++){
+      Py_XDECREF(arrays[i]);
+    }
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
+    Py_DECREF(count_obj);
+    return NULL;
+  }
+  
+  dataptr = NpyIter_GetDataPtrArray(iter);
+  i = 0;
+  do{
+    range_c[i] = *(double *)dataptr[0];
+    i++;
+  } while (iternext(iter));
+  NpyIter_Deallocate(iter);
+  
+  /* now we pre-compute the bin normalizations for all dimensions */
+  fndim = (double *)malloc(sizeof(double) * ndim);
+  norms = (double *)malloc(sizeof(double) * ndim);
+  for (int j = 0; j < ndim; j++){
+    fndim[j] = (double)dims[j];
+    norms[j] = fndim[j] / (range_c[j * 2 + 1] - range_c[j * 2]);
+  }
+  
+  dtypes = (PyArray_Descr **)malloc(sizeof(PyArray_Descr *) * ndim);
+  op_flags = (npy_uint32 *)malloc(sizeof(npy_uint32) * ndim);
+  for (int i = 0; i < ndim; i++){
+    dtypes[i] = PyArray_DescrFromType(NPY_DOUBLE);
+    op_flags[i] = NPY_ITER_READONLY;
+  }
+  iter = NpyIter_AdvancedNew(ndim, arrays,
+                             NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
+                             NPY_KEEPORDER, NPY_SAFE_CASTING, op_flags, dtypes,
+                             -1, NULL, NULL, 0);
+  if (iter == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
+    for (int i = 0; i < ndim; i++){
+     Py_XDECREF(arrays[i]);
+    }
+    Py_DECREF(count_obj);
+    //Py_DECREF(count_array);
+    return NULL;
+  }
+
+  /*
+   * The iternext function gets stored in a local variable
+   * so it can be called repeatedly in an efficient manner.
+   */
+  iternext = NpyIter_GetIterNext(iter, NULL);
+  if (iternext == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
+    NpyIter_Deallocate(iter);
+    for (int i = 0; i < ndim; i++){
+      Py_XDECREF(arrays[i]);
+    }
+    Py_DECREF(count_obj);
+    //Py_DECREF(count_array);
+    return NULL;
+  }
+
+  /* The location of the data pointer which the iterator may update */
+  dataptr = NpyIter_GetDataPtrArray(iter);
+
+  /* The location of the stride which the iterator may update */
+  strideptr = NpyIter_GetInnerStrideArray(iter);
+
+  /* The location of the inner loop size which the iterator may update */
+  innersizeptr = NpyIter_GetInnerLoopSizePtr(iter);
+
+  /* Get C array for output array */
+  count = (double *)PyArray_DATA(count_array);
+
+  Py_BEGIN_ALLOW_THREADS
+
+  do {
+    /* Get the inner loop data/stride/count values */
+    npy_intp size = *innersizeptr;
+    int idim;
+    /* This is a typical inner loop for NPY_ITER_EXTERNAL_LOOP */
+    while (size--) {
+      bin_idx = 0;
+      in_range = 1;
+      multiplier = 1;
+      for (idim = 0; idim < ndim; idim++){
+        idx = ndim - 1 - idim;  // reverse order of dimensions: z, y, x
+        xmin = range_c[idx * 2];
+        xmax = range_c[idx * 2 + 1];
+        tx = *(double *)dataptr[idx];  
+        if (tx < xmin || tx > xmax){
+          in_range = 0;
+        }
+        local_bin_idx = (tx - xmin) * norms[idx];
+        bin_idx += multiplier * local_bin_idx;
+        multiplier *= (int)dims[idx];
+        // This should lead to a bin index that behaves as follows:
+        //  1D: bin_idx = ix
+        //  2D: bin_idx = iy + ny * ix
+        //  3D: bin_idx = iz + nz * iy + nz * ny * ix
+        //  Notice how the order of multiplication requires that we step through the 
+        //  dimensions backwards.
+      }
+      
+      if (in_range){
+        count[bin_idx] += 1;
+      }
+      for (idim = 0; idim < ndim; idim++){
+        dataptr[idim] += strideptr[idim];
+      }
+    }
+
+  } while (iternext(iter));
+
+  Py_END_ALLOW_THREADS
+
+  NpyIter_Deallocate(iter);
+  for (int i = 0; i < ndim; i++){
+    Py_XDECREF(arrays[i]);
+  }
+  Py_XDECREF(range);
+  Py_XDECREF(bins);
   return count_obj;
 }
 

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -394,6 +394,7 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
     }
     Py_XDECREF(range);
     Py_XDECREF(bins);
+    free(arrays);
     return NULL;
   }
   
@@ -408,6 +409,7 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
         }
         Py_XDECREF(range);
         Py_XDECREF(bins);
+        free(arrays);
         return NULL;
       }
     }
@@ -423,6 +425,7 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
     }
     Py_XDECREF(range);
     Py_XDECREF(bins);
+    free(arrays);
     return NULL;
   }
   iternext = NpyIter_GetIterNext(iter, NULL);
@@ -434,6 +437,7 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
     NpyIter_Deallocate(iter);
     Py_XDECREF(range);
     Py_XDECREF(bins);
+    free(arrays);
     return NULL;
   }
   dataptr = NpyIter_GetDataPtrArray(iter);
@@ -455,6 +459,8 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
     Py_XDECREF(range);
     Py_XDECREF(bins);
     Py_XDECREF(count_obj);
+    free(arrays);
+    free(dims);
     return NULL;
   }
 
@@ -468,6 +474,8 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
     }
     Py_XDECREF(range);
     Py_XDECREF(bins);
+    free(arrays);
+    free(dims);
     return count_obj;
   }
 
@@ -484,6 +492,9 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
     Py_XDECREF(range);
     Py_XDECREF(bins);
     Py_DECREF(count_obj);
+    free(arrays);
+    free(dims);
+    free(range_c);
     return NULL;
   }
   iternext = NpyIter_GetIterNext(iter, NULL);
@@ -496,6 +507,9 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
     Py_XDECREF(range);
     Py_XDECREF(bins);
     Py_DECREF(count_obj);
+    free(arrays);
+    free(dims);
+    free(range_c);
     return NULL;
   }
   
@@ -531,7 +545,13 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
      Py_XDECREF(arrays[i]);
     }
     Py_DECREF(count_obj);
-    //Py_DECREF(count_array);
+    free(arrays);
+    free(dims);
+    free(range_c);
+    free(fndim);
+    free(norms);
+    free(dtypes);
+    free(op_flags);
     return NULL;
   }
 
@@ -547,7 +567,13 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
       Py_XDECREF(arrays[i]);
     }
     Py_DECREF(count_obj);
-    //Py_DECREF(count_array);
+    free(arrays);
+    free(dims);
+    free(range_c);
+    free(fndim);
+    free(norms);
+    free(dtypes);
+    free(op_flags);
     return NULL;
   }
 
@@ -621,6 +647,14 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
   }
   Py_XDECREF(range);
   Py_XDECREF(bins);
+  free(arrays);
+  free(dims);
+  free(range_c);
+  free(fndim);
+  free(norms);
+  free(dtypes);
+  free(op_flags);
+  free(stride);
   return count_obj;
 }
 
@@ -996,6 +1030,7 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
     }
     Py_XDECREF(range);
     Py_XDECREF(bins);
+    free(arrays);
     return NULL;
   }
   
@@ -1009,6 +1044,7 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
       }
       Py_XDECREF(range);
       Py_XDECREF(bins);
+      free(arrays);
       return NULL;
     }
   }
@@ -1023,6 +1059,7 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
     }
     Py_XDECREF(range);
     Py_XDECREF(bins);
+    free(arrays);
     return NULL;
   }
   iternext = NpyIter_GetIterNext(iter, NULL);
@@ -1034,6 +1071,7 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
     NpyIter_Deallocate(iter);
     Py_XDECREF(range);
     Py_XDECREF(bins);
+    free(arrays);
     return NULL;
   }
   dataptr = NpyIter_GetDataPtrArray(iter);
@@ -1055,6 +1093,8 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
     Py_XDECREF(range);
     Py_XDECREF(bins);
     Py_XDECREF(count_obj);
+    free(arrays);
+    free(dims);
     return NULL;
   }
 
@@ -1068,6 +1108,8 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
     }
     Py_XDECREF(range);
     Py_XDECREF(bins);
+    free(arrays);
+    free(dims);
     return count_obj;
   }
 
@@ -1084,6 +1126,9 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
     Py_XDECREF(range);
     Py_XDECREF(bins);
     Py_DECREF(count_obj);
+    free(arrays);
+    free(dims);
+    free(range_c);
     return NULL;
   }
   iternext = NpyIter_GetIterNext(iter, NULL);
@@ -1096,6 +1141,9 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
     Py_XDECREF(range);
     Py_XDECREF(bins);
     Py_DECREF(count_obj);
+    free(arrays);
+    free(dims);
+    free(range_c);
     return NULL;
   }
   
@@ -1131,7 +1179,13 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
      Py_XDECREF(arrays[i]);
     }
     Py_DECREF(count_obj);
-    //Py_DECREF(count_array);
+    free(arrays);
+    free(dims);
+    free(range_c);
+    free(fndim);
+    free(norms);
+    free(dtypes);
+    free(op_flags);
     return NULL;
   }
 
@@ -1147,7 +1201,13 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
       Py_XDECREF(arrays[i]);
     }
     Py_DECREF(count_obj);
-    //Py_DECREF(count_array);
+    free(arrays);
+    free(dims);
+    free(range_c);
+    free(fndim);
+    free(norms);
+    free(dtypes);
+    free(op_flags);
     return NULL;
   }
 
@@ -1224,5 +1284,13 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
   }
   Py_XDECREF(range);
   Py_XDECREF(bins);
+  free(arrays);
+  free(dims);
+  free(range_c);
+  free(fndim);
+  free(norms);
+  free(dtypes);
+  free(op_flags);
+  free(stride);
   return count_obj;
 }

--- a/fast_histogram/histogram.py
+++ b/fast_histogram/histogram.py
@@ -6,10 +6,11 @@ import numpy as np
 
 from ._histogram_core import (_histogram1d,
                               _histogram2d,
+                              _histogramdd,
                               _histogram1d_weighted,
                               _histogram2d_weighted)
 
-__all__ = ['histogram1d', 'histogram2d']
+__all__ = ['histogram1d', 'histogram2d', 'histogramdd']
 
 
 def histogram1d(x, bins, range, weights=None):
@@ -119,3 +120,17 @@ def histogram2d(x, y, bins, range, weights=None):
         return _histogram2d(x, y, nx, xmin, xmax, ny, ymin, ymax)
     else:
         return _histogram2d_weighted(x, y, weights, nx, xmin, xmax, ny, ymin, ymax)
+
+def histogramdd(sample, bins, range):
+    """
+    Compute a histogram in arbitrarily high dimensions.
+    
+    Parameters
+    ----------
+    sample : tuple of `~numpy.ndarray`
+        The position of the points to bin in the histogram. Each array in the tuple
+        contains the coordinates of one dimension.
+    
+    """
+    
+    return _histogramdd(sample, bins.astype(np.intp), range.astype(np.double))

--- a/fast_histogram/histogram.py
+++ b/fast_histogram/histogram.py
@@ -145,8 +145,31 @@ def histogramdd(sample, bins, range, weights=None):
     array : `~numpy.ndarray`
         The ND histogram array
     """
-
-    if weights is None:
-        return _histogramdd(sample, bins.astype(np.intp), range.astype(np.double))
+    
+    ndim = len(sample)
+    n = len(sample[0])
+    
+    if isinstance(bins, numbers.Integral):
+        _bins = bins * np.ones(ndim, dtype=np.intp)
     else:
-        return _histogramdd_weighted(sample, bins.astype(np.intp), range.astype(np.double), weights)
+        _bins = np.array(bins, dtype=np.intp)
+    if len(_bins) != ndim:
+        raise ValueError("number of bin counts does not match number of dimensions")
+    if np.any(_bins <= 0):
+        raise ValueError("all bin numbers should be strictly positive")
+    
+    _range = np.zeros((ndim, 2), dtype=np.double)
+    if not len(range) == ndim:
+        raise ValueError("number of ranges does not equal number of dimensions")
+    for i, r in enumerate(range):
+        if not len(r) == 2:
+            raise ValueError("should pass a minimum and maximum value for each dimension")
+        if r[0] >= r[1]:
+            raise ValueError("each range should be strictly increasing")
+        _range[i][0] = r[0]
+        _range[i][1] = r[1]
+    
+    if weights is None:
+        return _histogramdd(sample, _bins, _range)
+    else:
+        return _histogramdd_weighted(sample, _bins, _range, weights)

--- a/fast_histogram/histogram.py
+++ b/fast_histogram/histogram.py
@@ -8,7 +8,8 @@ from ._histogram_core import (_histogram1d,
                               _histogram2d,
                               _histogramdd,
                               _histogram1d_weighted,
-                              _histogram2d_weighted)
+                              _histogram2d_weighted,
+                              _histogramdd_weighted)
 
 __all__ = ['histogram1d', 'histogram2d', 'histogramdd']
 
@@ -121,7 +122,7 @@ def histogram2d(x, y, bins, range, weights=None):
     else:
         return _histogram2d_weighted(x, y, weights, nx, xmin, xmax, ny, ymin, ymax)
 
-def histogramdd(sample, bins, range):
+def histogramdd(sample, bins, range, weights=None):
     """
     Compute a histogram in arbitrarily high dimensions.
     
@@ -130,7 +131,22 @@ def histogramdd(sample, bins, range):
     sample : tuple of `~numpy.ndarray`
         The position of the points to bin in the histogram. Each array in the tuple
         contains the coordinates of one dimension.
-    
+    bins : int or iterable
+        The number of bins in each dimension. If given as an integer, the same
+        number of bins is used for each dimension.
+    range : iterable
+        The range to use in each dimention, as an iterable of value pairs, i.e.
+        [(xmin, xmax), (ymin, ymax)]
+    weights : `~numpy.ndarray`
+        The weights of the points in `sample`.
+
+    Returns
+    -------
+    array : `~numpy.ndarray`
+        The ND histogram array
     """
-    
-    return _histogramdd(sample, bins.astype(np.intp), range.astype(np.double))
+
+    if weights is None:
+        return _histogramdd(sample, bins.astype(np.intp), range.astype(np.double))
+    else:
+        return _histogramdd_weighted(sample, bins.astype(np.intp), range.astype(np.double), weights)

--- a/fast_histogram/tests/test_histogram.py
+++ b/fast_histogram/tests/test_histogram.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import pytest
 
-from hypothesis import given, settings, assume
+from hypothesis import given, settings, assume, example
 from hypothesis import strategies as st
 from hypothesis import HealthCheck
 from hypothesis.extra.numpy import arrays
@@ -133,27 +133,33 @@ def test_2d_compare_with_numpy(values, nx, xmin, xmax, ny, ymin, ymax, weights, 
 
 @given(values=arrays(dtype='<f8', shape=st.integers(0, 1000),
                      elements=st.floats(-1000, 1000), unique=True),
-       hist_size=st.integers(1, 1e4),
-       ndim=st.integers(1, 10),
-       xmin=st.floats(-1e10, 1e10), xmax=st.floats(-1e10, 1e10),
+       hist_size=st.integers(1, 1e5),
+       bins=arrays(elements=st.integers(1, 10), shape=(10,), dtype=np.int32),
+       ranges=arrays(elements=st.floats(1e-10, 1e5), dtype='<f8',
+                     shape=(10,), unique=True),
        weights=st.booleans(),
        dtype=st.sampled_from(['>f4', '<f4', '>f8', '<f8']))
 @settings(max_examples=500, suppress_health_check=[HealthCheck.too_slow])
-def test_dd_compare_with_numpy(values, hist_size, ndim, xmin, xmax, weights, dtype):
+def test_dd_compare_with_numpy(values, hist_size, bins, ranges, weights, dtype):
 
-    if xmax <= xmin:
-        return
-    
-    # We need to limit the number of bins in total so that we don't create examples that
-    # simply explode in size. In particular, np.histogramdd has a large intermediate
-    # memory requirement. That's why we sample a total hist size and a number of
-    # dimensions and calculate the bin size that would fit. The equation below yields
-    # the largest number of bins that creates a histogram that has at most the size
-    # hist_size.
-    bins = np.floor(np.exp(np.log(hist_size) / ndim)).astype(np.int32)
-    
+    # To avoid generating huge histograms that take a long time, we only take
+    # as many dimensions as we can such that the total hist_size is still within the
+    # limit. If `hist_size = 1`, we will take all the leading ones in `bins`.
+    _bins = []
+    accum_size = 1
+    for i in range(10):
+        if bins[i] * accum_size > hist_size:
+            break
+        _bins.append(bins[i]) 
+        accum_size *= bins[i]
+    ndim = len(_bins)
     values = values.astype(dtype)
-
+    ranges = ranges.astype(dtype)
+    ranges = ranges[:ndim]
+    # Ranges are symmetric because otherwise the probability of samples falling inside
+    # is just too small and we would just be testing a bunch of empty histograms.
+    ranges = np.vstack((-ranges, ranges)).T
+    
     size = len(values) // (ndim + 1)
 
     if weights:
@@ -163,9 +169,8 @@ def test_dd_compare_with_numpy(values, hist_size, ndim, xmin, xmax, weights, dty
     
     sample = tuple(values[size*(i+1):size*(i+2)] for i in range(ndim))
     # for simplicity using the same range in all dimensions
-    ranges = tuple((xmin, xmax) for i in range(ndim))
     try:
-        reference = np.histogramdd(sample, bins=bins, weights=w, range=ranges)[0]
+        reference = np.histogramdd(sample, bins=_bins, weights=w, range=ranges)[0]
     except Exception:
         # If Numpy fails, we skip the comparison since this isn't our fault
         return
@@ -173,17 +178,17 @@ def test_dd_compare_with_numpy(values, hist_size, ndim, xmin, xmax, weights, dty
     # First, check the Numpy result because it sometimes doesn't make sense. See
     # bug report https://github.com/numpy/numpy/issues/9435.
     # FIXME: for now use < since that's what our algorithm does
-    inside = (sample[0] < xmax) & (sample[0] >= xmin)
+    inside = (sample[0] < ranges[0][1]) & (sample[0] >= ranges[0][0])
     if ndim > 1:
         for i in range(ndim - 1):
-            inside = inside & (sample[i+1] < xmax) & (sample[i+1] >= xmin)
+            inside = inside & (sample[i+1] < ranges[i+1][1]) & (sample[i+1] >= ranges[i+1][0])
     if weights:
         assume(np.allclose(np.sum(w[inside]), np.sum(reference)))
     else:
         n_inside = np.sum(inside)
         assume(n_inside == np.sum(reference))
 
-    fast = histogramdd(sample, bins=bins, weights=w, range=ranges)
+    fast = histogramdd(sample, bins=_bins, weights=w, range=ranges)
 
     if sample[0].dtype.kind == 'f' and sample[0].dtype.itemsize == 4:
         rtol = 1e-7

--- a/fast_histogram/tests/test_histogram.py
+++ b/fast_histogram/tests/test_histogram.py
@@ -139,7 +139,7 @@ def test_2d_compare_with_numpy(values, nx, xmin, xmax, ny, ymin, ymax, weights, 
                      shape=(10,), unique=True),
        weights=st.booleans(),
        dtype=st.sampled_from(['>f4', '<f4', '>f8', '<f8']))
-@settings(max_examples=500, suppress_health_check=[HealthCheck.too_slow])
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow], deadline=None)
 def test_dd_compare_with_numpy(values, hist_size, bins, ranges, weights, dtype):
 
     # To avoid generating huge histograms that take a long time, we only take

--- a/fast_histogram/tests/test_histogram.py
+++ b/fast_histogram/tests/test_histogram.py
@@ -4,6 +4,7 @@ import pytest
 
 from hypothesis import given, settings, assume
 from hypothesis import strategies as st
+from hypothesis import HealthCheck
 from hypothesis.extra.numpy import arrays
 
 from ..histogram import histogram1d, histogram2d, histogramdd
@@ -137,7 +138,7 @@ def test_2d_compare_with_numpy(values, nx, xmin, xmax, ny, ymin, ymax, weights, 
        xmin=st.floats(-1e10, 1e10), xmax=st.floats(-1e10, 1e10),
        weights=st.booleans(),
        dtype=st.sampled_from(['>f4', '<f4', '>f8', '<f8']))
-@settings(max_examples=500)
+@settings(max_examples=500, suppress_health_check=[HealthCheck.too_slow])
 def test_dd_compare_with_numpy(values, hist_size, ndim, xmin, xmax, weights, dtype):
 
     if xmax <= xmin:


### PR DESCRIPTION
Hi all,

I happen to have a (scientific) application where I need fast histograms, and I found this package very promising to be exactly what I need! If it would only support histograms in arbitrary dimensions, it would be perfect... and I think that I did in fact manage to pull it off. :) 

This PR adds the function `histogramdd` to the package. 

It is a straight generalization of the 1D and 2D code, only that the input sample is given as a tuple. The code discovers automatically how many arrays there are in the tuple and generates the output dimensions accordingly. If the dimension is `D` and the number of samples `N`, then the tuple must contain `D` arrays with `N` elements. Bins and ranges are passed as arrays as well with shapes `(D,)` and `(D, 2)`, respectively to pass the number of bins as well as the ranges for each dimension. 

The output of `histogram2d(x, y, range, bins)` should be the same as `histogramdd((x, y), range, bins)`. The speed of the generalized function is a bit slower, so it is still beneficial to use the dedicated 1D and 2D functions where appropriate. 

I'm also working on the weighted version but I thought I'd make a PR to get some feedback. This is still missing tests and documentation, and maybe someone with more C and numpy API experience could have a look if there is any possibility to make things a little bit faster still to match the performance of the 1D and 2D code. 