### PR TITLE
Make behavior at upper bin edge consistent with between 1D, 2D and DD

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 -----------------
 
 - Add function for histograms in arbitrarily high dimensions.
+- Make behavior for data point at the uppermost bin edge consistent with numpy. [#10]
 
 0.9 (2020-05-24)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,6 @@
 -----------------
 
 - Add function for histograms in arbitrarily high dimensions.
-- Make behavior for data point at the uppermost bin edge consistent with numpy. [#10]
 
 0.9 (2020-05-24)
 ----------------

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -168,11 +168,8 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args) {
 
       tx = *(double *)dataptr[0];
 
-      if (tx >= xmin && tx <= xmax) {
+      if (tx >= xmin && tx < xmax) {
         ix = (tx - xmin) * normx;
-        if (ix == nx){
-          ix = nx - 1;
-        }
         count[ix] += 1.;
       }
 
@@ -321,15 +318,9 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
       tx = *(double *)dataptr[0];
       ty = *(double *)dataptr[1];
 
-      if (tx >= xmin && tx <= xmax && ty >= ymin && ty <= ymax) {
+      if (tx >= xmin && tx < xmax && ty >= ymin && ty < ymax) {
         ix = (tx - xmin) * normx;
-        if (ix == nx){
-          ix = nx - 1;
-        }
         iy = (ty - ymin) * normy;
-        if (iy == ny){
-          iy = ny - 1;
-        }
         count[iy + ny * ix] += 1.;
       }
 
@@ -634,13 +625,10 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
         xmax = range_c[i * 2 + 1];
         tx = *(double *)dataptr[i];  
         dataptr[i] += strideptr[i];
-        if (tx < xmin || tx > xmax){
+        if (tx < xmin || tx >= xmax){
           in_range = 0;
         } else {
           local_bin_idx = (tx - xmin) * norms[i];
-          if (local_bin_idx == (int)dims[i]){
-            local_bin_idx = (int)dims[i] - 1;
-          }
           bin_idx += stride[i] * local_bin_idx;
         }
       }
@@ -797,11 +785,8 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args) {
       tx = *(double *)dataptr[0];
       tw = *(double *)dataptr[1];
 
-      if (tx >= xmin && tx <= xmax) {
+      if (tx >= xmin && tx < xmax) {
         ix = (tx - xmin) * normx;
-        if (ix == nx){
-          ix = ix - 1;
-        }
         count[ix] += tw;
       }
 
@@ -962,15 +947,9 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args) {
       ty = *(double *)dataptr[1];
       tw = *(double *)dataptr[2];
 
-      if (tx >= xmin && tx <= xmax && ty >= ymin && ty <= ymax) {
+      if (tx >= xmin && tx < xmax && ty >= ymin && ty < ymax) {
         ix = (tx - xmin) * normx;
-        if (ix == nx){
-          ix = nx - 1;
-        }
         iy = (ty - ymin) * normy;
-        if (iy == ny){
-          iy = ny - 1;
-        }
         count[iy + ny * ix] += tw;
       }
 
@@ -1280,13 +1259,10 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
         xmax = range_c[i * 2 + 1];
         tx = *(double *)dataptr[i];  
         dataptr[i] += strideptr[i];
-        if (tx < xmin || tx > xmax){
+        if (tx < xmin || tx >= xmax){
           in_range = 0;
         } else {
           local_bin_idx = (tx - xmin) * norms[i];
-          if (local_bin_idx == (int)dims[i]){
-            local_bin_idx = (int)dims[i] - 1;
-          }
           bin_idx += stride[i] * local_bin_idx;
         }
       }

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -168,8 +168,11 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args) {
 
       tx = *(double *)dataptr[0];
 
-      if (tx >= xmin && tx < xmax) {
+      if (tx >= xmin && tx <= xmax) {
         ix = (tx - xmin) * normx;
+        if (ix == nx){
+          ix = nx - 1;
+        }
         count[ix] += 1.;
       }
 
@@ -318,9 +321,15 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
       tx = *(double *)dataptr[0];
       ty = *(double *)dataptr[1];
 
-      if (tx >= xmin && tx < xmax && ty >= ymin && ty < ymax) {
+      if (tx >= xmin && tx <= xmax && ty >= ymin && ty <= ymax) {
         ix = (tx - xmin) * normx;
+        if (ix == nx){
+          ix = nx - 1;
+        }
         iy = (ty - ymin) * normy;
+        if (iy == ny){
+          iy = ny - 1;
+        }
         count[iy + ny * ix] += 1.;
       }
 
@@ -629,6 +638,9 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
           in_range = 0;
         } else {
           local_bin_idx = (tx - xmin) * norms[i];
+          if (local_bin_idx == (int)dims[i]){
+            local_bin_idx = (int)dims[i] - 1;
+          }
           bin_idx += stride[i] * local_bin_idx;
         }
       }
@@ -785,8 +797,11 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args) {
       tx = *(double *)dataptr[0];
       tw = *(double *)dataptr[1];
 
-      if (tx >= xmin && tx < xmax) {
+      if (tx >= xmin && tx <= xmax) {
         ix = (tx - xmin) * normx;
+        if (ix == nx){
+          ix = ix - 1;
+        }
         count[ix] += tw;
       }
 
@@ -947,9 +962,15 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args) {
       ty = *(double *)dataptr[1];
       tw = *(double *)dataptr[2];
 
-      if (tx >= xmin && tx < xmax && ty >= ymin && ty < ymax) {
+      if (tx >= xmin && tx <= xmax && ty >= ymin && ty <= ymax) {
         ix = (tx - xmin) * normx;
+        if (ix == nx){
+          ix = nx - 1;
+        }
         iy = (ty - ymin) * normy;
+        if (iy == ny){
+          iy = ny - 1;
+        }
         count[iy + ny * ix] += tw;
       }
 
@@ -1263,6 +1284,9 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
           in_range = 0;
         } else {
           local_bin_idx = (tx - xmin) * norms[i];
+          if (local_bin_idx == (int)dims[i]){
+            local_bin_idx = (int)dims[i] - 1;
+          }
           bin_idx += stride[i] * local_bin_idx;
         }
       }

--- a/fast_histogram/tests/test_histogram.py
+++ b/fast_histogram/tests/test_histogram.py
@@ -287,40 +287,6 @@ def test_histogramdd_interface():
     result_fh = histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
     np.testing.assert_equal(result_np, result_fh)
     
-def test_bin_edge_inclusivity():
-    # All bin intervals are closed on the left side and open on the right side, 
-    # but in numpy the last bin interval is closed on both sides.
-    # That means if we have
-    #     x = np.arange(11)
-    # Then numpy gives
-    #     np.histogram(x, bins=10, range=(0, 10))[0]
-    #     ---> array([1, 1, 1, 1, 1, 1, 1, 1, 1, 2])
-    # In 2D, values at the edges of all dimensions can be included:
-    #     X, Y = np.meshgrid(np.arange(4), np.arange(4))
-    #     np.histogram2d(X.ravel(), Y.ravel(), bins=(3,3), range=((0, 3), (0, 3)))
-    #     ---> (array([[1., 1., 2.],
-    #                  [1., 1., 2.],
-    #                  [2., 2., 4.]]),
-    #           array([0., 1., 2., 3.]),
-    #           array([0., 1., 2., 3.]))
-    
-    # testing 1D
-    x = np.arange(11)
-    result_np = np.histogram(x, bins=10, range=(0, 10))[0]
-    result_fh = histogram1d(x, bins=10, range=(0, 10))
-    result_dd = histogramdd((x,), bins=[10], range=[(0, 10)])
-    np.testing.assert_equal(result_np, result_fh)
-    np.testing.assert_equal(result_np, result_dd)
-
-    # testing 2D
-    X, Y = np.meshgrid(np.arange(4), np.arange(4))
-    result_np = np.histogram2d(X.ravel(), Y.ravel(),
-                               bins=(3, 3), range=((0, 3), (0, 3)))[0]
-    result_fh = histogram2d(X.ravel(), Y.ravel(), bins=(3, 3), range=((0, 3), (0, 3)))
-    result_dd = histogramdd((X.ravel(), Y.ravel()), bins=(3, 3), range=((0, 3), (0, 3)))
-    np.testing.assert_equal(result_np, result_fh)
-    np.testing.assert_equal(result_np, result_dd)
-
 def test_non_contiguous():
 
     x = np.random.random((10, 10, 10))[::2, ::3, :]

--- a/fast_histogram/tests/test_histogram.py
+++ b/fast_histogram/tests/test_histogram.py
@@ -232,11 +232,61 @@ def test_list():
 
     np.testing.assert_equal(result_list, result_arr)
     
-    result_list_dd = histogramdd((x_list,), bins=10, range=((0, 10),))
-    result_arr_dd = histogramdd((x_arr,), bins=10, range=((0, 10),))
+    result_list_dd = histogramdd(x_list, bins=10, range=((0, 10),))
+    result_arr_dd = histogramdd(x_arr, bins=10, range=((0, 10),))
 
     np.testing.assert_equal(result_list_dd, result_arr_dd)
 
+def test_histogramdd_interface():
+    # make sure the interface of histogramdd works as numpy.histogramdd
+    x_list = [1.4, 2.1, 4.2, 8.7, 5.1]
+    x_arr = np.array(x_list)
+    y_list = [6.6, 3.2, 2.9, 3.9, 0.1]
+    y_arr = np.array(y_list)
+    
+    # test 1D (needs special handling in case the sample is a list)
+    sample = x_arr
+    result_np, _ = np.histogramdd(sample, bins=10, range=((0, 10),))
+    result_fh = histogramdd(sample, bins=10, range=((0, 10),))
+    np.testing.assert_equal(result_np, result_fh)
+    
+    sample = x_list
+    result_np, _ = np.histogramdd(sample, bins=10, range=((0, 10),))
+    result_fh = histogramdd(sample, bins=10, range=((0, 10),))
+    np.testing.assert_equal(result_np, result_fh)
+    
+    # test (D, N) array_like
+    sample = (x_arr, y_arr)
+    result_np, _ = np.histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    result_fh = histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    np.testing.assert_equal(result_np, result_fh)
+    
+    sample = [x_arr, y_arr]
+    result_np, _ = np.histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    result_fh = histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    np.testing.assert_equal(result_np, result_fh)
+    
+    sample = (x_list, y_list)
+    result_np, _ = np.histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    result_fh = histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    np.testing.assert_equal(result_np, result_fh)
+    
+    sample = [x_list, y_list]
+    result_np, _ = np.histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    result_fh = histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    np.testing.assert_equal(result_np, result_fh)
+    
+    # test (N, D) array
+    sample = np.vstack([x_arr, y_arr]).T
+    result_np, _ = np.histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    result_fh = histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    np.testing.assert_equal(result_np, result_fh)
+    
+    sample = np.vstack([x_list, y_list]).T
+    result_np, _ = np.histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    result_fh = histogramdd(sample, bins=10, range=((0, 10), (0, 10)))
+    np.testing.assert_equal(result_np, result_fh)
+    
 def test_bin_edge_inclusivity():
     # All bin intervals are closed on the left side and open on the right side, 
     # but in numpy the last bin interval is closed on both sides.

--- a/fast_histogram/tests/test_histogram.py
+++ b/fast_histogram/tests/test_histogram.py
@@ -237,6 +237,39 @@ def test_list():
 
     np.testing.assert_equal(result_list_dd, result_arr_dd)
 
+def test_bin_edge_inclusivity():
+    # All bin intervals are closed on the left side and open on the right side, 
+    # but in numpy the last bin interval is closed on both sides.
+    # That means if we have
+    #     x = np.arange(11)
+    # Then numpy gives
+    #     np.histogram(x, bins=10, range=(0, 10))[0]
+    #     ---> array([1, 1, 1, 1, 1, 1, 1, 1, 1, 2])
+    # In 2D, values at the edges of all dimensions can be included:
+    #     X, Y = np.meshgrid(np.arange(4), np.arange(4))
+    #     np.histogram2d(X.ravel(), Y.ravel(), bins=(3,3), range=((0, 3), (0, 3)))
+    #     ---> (array([[1., 1., 2.],
+    #                  [1., 1., 2.],
+    #                  [2., 2., 4.]]),
+    #           array([0., 1., 2., 3.]),
+    #           array([0., 1., 2., 3.]))
+    
+    # testing 1D
+    x = np.arange(11)
+    result_np = np.histogram(x, bins=10, range=(0, 10))[0]
+    result_fh = histogram1d(x, bins=10, range=(0, 10))
+    result_dd = histogramdd((x,), bins=[10], range=[(0, 10)])
+    np.testing.assert_equal(result_np, result_fh)
+    np.testing.assert_equal(result_np, result_dd)
+
+    # testing 2D
+    X, Y = np.meshgrid(np.arange(4), np.arange(4))
+    result_np = np.histogram2d(X.ravel(), Y.ravel(),
+                               bins=(3, 3), range=((0, 3), (0, 3)))[0]
+    result_fh = histogram2d(X.ravel(), Y.ravel(), bins=(3, 3), range=((0, 3), (0, 3)))
+    result_dd = histogramdd((X.ravel(), Y.ravel()), bins=(3, 3), range=((0, 3), (0, 3)))
+    np.testing.assert_equal(result_np, result_fh)
+    np.testing.assert_equal(result_np, result_dd)
 
 def test_non_contiguous():
 


### PR DESCRIPTION
This PR contains one critical fix and one fix for consistency [issue #10] .

Critically, when a data point was exactly at the upper edge of all binning dimensions, then the `bin_idx` in [histogramdd, L636](https://github.com/astrofrog/fast-histogram/blob/7913e8fc901efa96eee941e654b8f632e85ba357/fast_histogram/_histogram_core.c#L636) could become equal to the array size and thus would cause it to write outside of the allocated memory, causing a segfault.

I added checks whether a data point is at the uppermost border in each binning, and if so, the count will be added to the last bin, consistently with `numpy`'s behavior. This does cause a little drop in performance and I tried various different ways of implementing this (if statements, triple operators, subtraction of `ix/nx`) and found that adding simple `if` statements cost the least in the end. The speedup is ~80 % of what it used to be on my machine vs. `numpy`.

This is the benchmark result on my machine without the checks:
![speedup_compared_open_bins](https://user-images.githubusercontent.com/11697666/128392088-0b772127-8b8e-448a-ab51-148979a4caed.png)

And this is what I am getting now with the check:
![speedup_compared_if_statements](https://user-images.githubusercontent.com/11697666/128392214-8de65c0f-2985-4eb7-947c-17ad1965ad74.png)

In my mind this would still be an acceptable performance, but we could also choose to break with consistency with `numpy` here. In that case, I would fix the issue with `histogramdd` by changing one `>` to an `>=` when I check whether the point is in range.