### PR TITLE
Enable PyPy and musllinux builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,5 +45,6 @@ jobs:
     with:
       test_extras: test
       test_command: pytest --pyargs fast_histogram -m "not hypothesis"
+      sdist-runs-on: ubuntu-22.04
     secrets:
       pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       coverage: codecov
+      runs-on: |
+        linux: ubuntu-22.04
       envs: |
         - linux: py36-test-numpy113
         - linux: py36-test-numpy114

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,6 @@ jobs:
       runs-on: |
         linux: ubuntu-22.04
       envs: |
-        - linux: py36-test-numpy113
-        - linux: py36-test-numpy114
-        - linux: py36-test-numpy115
         - linux: py37-test-numpy116
         - linux: py37-test-numpy117
         - linux: py38-test-numpy118

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,5 +45,11 @@ jobs:
       test_extras: test
       test_command: pytest --pyargs fast_histogram -m "not hypothesis"
       sdist-runs-on: ubuntu-22.04
+      targets: |
+        - cp*manylinux*
+        - cp*musllinux*
+        - pp*
+        - macos
+        - windows
     secrets:
       pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -1,12 +1,6 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #define Py_LIMITED_API 0x030600f0
 
-// The following struct definition is to avoid a GCC bug - see
-// https://github.com/numpy/numpy/issues/16970 for more details.
-struct _typeobject {
-  int foo;
-};
-
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include <numpy/npy_math.h>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,10 @@ requires = ["setuptools",
             "oldest-supported-numpy"]
 build-backend = 'setuptools.build_meta'
 
-[tool.cibuildwheel]
-skip = "pp* *-musllinux*"
+[tool.cibuildwheel.linux.environment]
+CC = "gcc"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+before-all = "apk add clang"
+environment = { CC="clang" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ requires = ["setuptools",
             "oldest-supported-numpy"]
 build-backend = 'setuptools.build_meta'
 
+[tool.cibuildwheel.macos]
+skip = "pp*"
+
+[tool.cibuildwheel.windows]
+skip = "pp*"
+
 [tool.cibuildwheel.linux.environment]
 CC = "gcc"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ requires = ["setuptools",
             "oldest-supported-numpy"]
 build-backend = 'setuptools.build_meta'
 
+[tool.cibuildwheel.linux]
+skip = "*-musllinux_i686"
+
 [tool.cibuildwheel.macos]
 skip = "pp*"
 


### PR DESCRIPTION
This also removes the workaround for gcc<10 by ensuring that we always use gcc>=10 or clang