### PR TITLE
Remove wheel from build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools",
             "setuptools_scm",
-            "wheel",
             "oldest-supported-numpy;python_version<'3.9'",
             "numpy>=1.25;python_version>='3.9'"]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
Someone said we don't need to include "wheel" anymore?