### PR TITLE
Clean up test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,15 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   tests:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
-      coverage: codecov
       runs-on: |
         linux: ubuntu-22.04
       envs: |
@@ -22,6 +25,7 @@ jobs:
         - linux: py310-test-numpy124
         - linux: py310-test-numpy125
         - linux: py311-test-numpy126
+        - linux: py312-test-numpydev
 
         - macos: py38-test-numpy118
         - macos: py39-test-numpy119

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ python_requires = >=3.8
 [options.extras_require]
 test =
     pytest
-    pytest-cov
     hypothesis[numpy]
 
 [bdist_wheel]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27, 35, 36,37,38}-test
+    py{38,39,310,311,312}-test{-numpy118,-numpy119,-numpy120,-numpy121,-numpy122,-numpy123,-numpy124,-numpy125,-numpy126,-numpydev}
     style
 requires =
     setuptools >= 30.3.0
@@ -8,23 +8,14 @@ requires =
 isolated_build = true
 
 [testenv]
+passenv = CI
+setenv =
+    numpydev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 changedir =
     test: .tmp/{envname}
-    build_docs: docs
 description =
     test: run tests with pytest
-    build_docs: invoke sphinx-build to build the HTML docs
-    all: run tests with all optional dependencies
-    dev: run tests with numpy and astropy dev versions
 deps =
-    numpy110: numpy==1.10.*
-    numpy111: numpy==1.11.*
-    numpy112: numpy==1.12.*
-    numpy113: numpy==1.13.*
-    numpy114: numpy==1.14.*
-    numpy115: numpy==1.15.*
-    numpy116: numpy==1.16.*
-    numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*
     numpy120: numpy==1.20.*
@@ -34,6 +25,7 @@ deps =
     numpy124: numpy==1.24.*
     numpy125: numpy==1.25.*
     numpy126: numpy==1.26.*
+    numpydev: numpy>=0.0.dev0
 extras =
     test
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py{38,39,310,311,312}-test{-numpy118,-numpy119,-numpy120,-numpy121,-numpy122,-numpy123,-numpy124,-numpy125,-numpy126,-numpydev}
-    style
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -31,9 +30,3 @@ extras =
 commands =
     pip freeze
     pytest --pyargs fast_histogram --hypothesis-show-statistics {posargs}
-
-[testenv:style]
-skip_install = true
-description = invoke style checks on package code
-deps = flake8
-commands = flake8 fast_histogram


### PR DESCRIPTION
* Some things like flake8, build_docs, and coverage are never used, so I removed them.
* tox options are outdated, so I synced them with what is actually used.
* Added Actions auto-cancel.
* Added a py312 + numpydev job (#73, #80)