### PR TITLE
Bump minimum required Python to 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
       runs-on: |
         linux: ubuntu-22.04
       envs: |
-        - linux: py38-test-numpy118
         - linux: py39-test-numpy119
         - linux: py39-test-numpy120
         - linux: py39-test-numpy121
@@ -28,7 +27,6 @@ jobs:
         - linux: py311-test-numpy20
         - linux: py312-test-numpydev
 
-        - macos: py38-test-numpy118
         - macos: py39-test-numpy119
         - macos: py39-test-numpy120
         - macos: py39-test-numpy121
@@ -39,7 +37,6 @@ jobs:
         - macos: py311-test-numpy126
         - macos: py311-test-numpy20
 
-        - windows: py38-test-numpy118
         - windows: py39-test-numpy119
         - windows: py39-test-numpy120
         - windows: py39-test-numpy121

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v3.15.2
     hooks:
       - id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
 
   - repo: https://github.com/psf/black
     rev: 24.4.0

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -1,5 +1,5 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#define Py_LIMITED_API 0x030800f0
+#define Py_LIMITED_API 0x030900f0
 
 #include <Python.h>
 #include <numpy/arrayobject.h>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = ["setuptools",
             "setuptools_scm",
-            "oldest-supported-numpy;python_version<'3.9'",
-            "numpy>=2.0.0rc1;python_version>='3.9'"]
+            "numpy>=2.0.0rc1"]
 build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel.linux]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ zip_safe = False
 packages = find:
 install_requires =
     numpy
-python_requires = >=3.8
+python_requires = >=3.9
 
 [options.extras_require]
 test =
@@ -20,4 +20,4 @@ test =
     hypothesis[numpy]
 
 [bdist_wheel]
-py_limited_api = cp38
+py_limited_api = cp39

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-test{-numpy118,-numpy119,-numpy120,-numpy121,-numpy122,-numpy123,-numpy124,-numpy125,-numpy126,-numpy20,-numpydev}
+    py{39,310,311,312}-test{-numpy118,-numpy119,-numpy120,-numpy121,-numpy122,-numpy123,-numpy124,-numpy125,-numpy126,-numpy20,-numpydev}
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1


### PR DESCRIPTION
As we are using the limited API, we need Python 3.9 wheels to be built to make sure that we use Numpy 2.0 to build them (otherwise we were building Python 3.8 wheels which were still done against Numpy 1.x)