### PR TITLE
EXP: Switch to meson to build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,14 @@
+project('purelib-and-platlib', 'c')
+
+py = import('python').find_installation(pure: false)
+
+npy_include_path = run_command(py, ['-c', 'import os; import numpy; print(os.path.abspath(numpy.get_include()))'],
+                         ).stdout().strip()
+
+py.extension_module(
+    'fast_histogram._histogram_core',
+    'fast_histogram/_histogram_core.c',
+    limited_api: '3.9',
+    include_directories: [npy_include_path],
+    install: true,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
-requires = ["setuptools",
-            "setuptools_scm",
-            "numpy>=2.0.0rc1"]
-build-backend = 'setuptools.build_meta'
+build-backend = 'mesonpy'
+requires = ['meson-python']
 
 [tool.cibuildwheel.linux]
 skip = "pp310* pp311* pp312*"
@@ -26,3 +24,25 @@ environment = { CC="clang" }
 [tool.isort]
 profile = "black"
 line_length = 100
+
+
+[project]
+name = "fast-histogram"
+description = "Fast simple 1D and 2D histograms"
+readme = "README.rst"
+requires-python = ">=3.9"
+dependencies = [ "numpy",]
+version = "1.0.0"
+
+[[project.authors]]
+name = "Thomas Robitaille"
+email = "thomas.robitaille@gmail.com"
+
+[project.license]
+text = "BSD"
+
+[project.urls]
+Homepage = "https://github.com/astrofrog/fast-histogram"
+
+[project.optional-dependencies]
+test = [ "pytest", "hypothesis[numpy]",]


### PR DESCRIPTION
I don't think we need to actually do this, but I am learning how to use meson to build Python packages and extensions for use in larger projects.