### PR TITLE
Fix memory safety bugs in _histogram_core.c

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,8 @@ jobs:
       sdist-runs-on: ubuntu-22.04
       targets: |
         - cp*-manylinux_x86_64
-        - cp*-manylinux_aarch64
+        - target: cp*-manylinux_aarch64
+          runs-on: ubuntu-24.04-arm
         - cp*-musllinux_x86_64
         # - cp*-musllinux_aarch64
         - pp*-manylinux_x86_64

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -360,6 +360,9 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
   }
 
   ndim = (int)PyTuple_Size(sample_obj);
+  if (ndim < 0) {
+    return NULL;
+  }
 
   /* Interpret the input objects as `numpy` arrays. */
   arrays = (PyArrayObject **)malloc(sizeof(PyArrayObject *) * ndim);
@@ -991,6 +994,9 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
   }
 
   ndim = (int)PyTuple_Size(sample_obj);
+  if (ndim < 0) {
+    return NULL;
+  }
 
   /* Interpret the input objects as `numpy` arrays. */
   arrays = (PyArrayObject **)malloc(sizeof(PyArrayObject *) * (ndim + 1));

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -114,7 +114,6 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
     Py_DECREF(x_array);
     Py_DECREF(count_obj);
-    Py_DECREF(count_array);
     return NULL;
   }
 
@@ -128,7 +127,6 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args) {
     NpyIter_Deallocate(iter);
     Py_DECREF(x_array);
     Py_DECREF(count_obj);
-    Py_DECREF(count_array);
     return NULL;
   }
 
@@ -260,7 +258,6 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
     Py_DECREF(x_array);
     Py_DECREF(y_array);
     Py_DECREF(count_obj);
-    Py_DECREF(count_array);
     return NULL;
   }
 
@@ -275,7 +272,6 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
     Py_DECREF(x_array);
     Py_DECREF(y_array);
     Py_DECREF(count_obj);
-    Py_DECREF(count_array);
     return NULL;
   }
 
@@ -732,7 +728,6 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args) {
     Py_DECREF(x_array);
     Py_DECREF(w_array);
     Py_DECREF(count_obj);
-    Py_DECREF(count_array);
     return NULL;
   }
 
@@ -747,7 +742,6 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args) {
     Py_DECREF(x_array);
     Py_DECREF(w_array);
     Py_DECREF(count_obj);
-    Py_DECREF(count_array);
     return NULL;
   }
 
@@ -890,7 +884,6 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args) {
     Py_DECREF(y_array);
     Py_DECREF(w_array);
     Py_DECREF(count_obj);
-    Py_DECREF(count_array);
     return NULL;
   }
 
@@ -906,7 +899,6 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args) {
     Py_DECREF(y_array);
     Py_DECREF(w_array);
     Py_DECREF(count_obj);
-    Py_DECREF(count_array);
     return NULL;
   }
 

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -552,6 +552,8 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
     for (int i = 0; i < ndim; i++){
      Py_XDECREF(arrays[i]);
     }
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
     Py_DECREF(count_obj);
     free(arrays);
     free(dims);
@@ -574,6 +576,8 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
     for (int i = 0; i < ndim; i++){
       Py_XDECREF(arrays[i]);
     }
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
     Py_DECREF(count_obj);
     free(arrays);
     free(dims);
@@ -1207,6 +1211,8 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
     for (int i = 0; i < ndim + 1; i++){
      Py_XDECREF(arrays[i]);
     }
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
     Py_DECREF(count_obj);
     free(arrays);
     free(dims);
@@ -1229,6 +1235,8 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
     for (int i = 0; i < ndim + 1; i++){
       Py_XDECREF(arrays[i]);
     }
+    Py_XDECREF(range);
+    Py_XDECREF(bins);
     Py_DECREF(count_obj);
     free(arrays);
     free(dims);

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -1,5 +1,5 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#define Py_LIMITED_API 0x030900f0
+#define Py_LIMITED_API 0x030a00f0
 
 #include <Python.h>
 #include <numpy/arrayobject.h>

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -401,7 +401,7 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
       if (!((long)PyArray_DIM(arrays[i], 0) == n)){
         PyErr_SetString(PyExc_RuntimeError, "Lengths of sample arrays do not match.");
         for (int j = 0; j < ndim; j++){
-          Py_XDECREF(arrays[i]);
+          Py_XDECREF(arrays[j]);
         }
         Py_XDECREF(range);
         Py_XDECREF(bins);

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -371,6 +371,9 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
 
   /* Interpret the input objects as `numpy` arrays. */
   arrays = (PyArrayObject **)malloc(sizeof(PyArrayObject *) * ndim);
+  if (arrays == NULL) {
+    return PyErr_NoMemory();
+  }
   sample_parsing_success = 1;
   for (int i = 0; i < ndim; i++){
     arrays[i] = (PyArrayObject *)PyArray_FROM_O(PyTuple_GetItem(sample_obj, i));
@@ -1020,6 +1023,9 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
 
   /* Interpret the input objects as `numpy` arrays. */
   arrays = (PyArrayObject **)malloc(sizeof(PyArrayObject *) * (ndim + 1));
+  if (arrays == NULL) {
+    return PyErr_NoMemory();
+  }
   sample_parsing_success = 1;
   for (int i = 0; i < ndim; i++){
     arrays[i] = (PyArrayObject *)PyArray_FROM_O(PyTuple_GetItem(sample_obj, i));

--- a/fast_histogram/_histogram_core.c
+++ b/fast_histogram/_histogram_core.c
@@ -110,6 +110,7 @@ static PyObject *_histogram1d(PyObject *self, PyObject *args) {
   iter = NpyIter_New(x_array,
                      NPY_ITER_READONLY | NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
                      NPY_KEEPORDER, NPY_SAFE_CASTING, dtype);
+  Py_DECREF(dtype);
   if (iter == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
     Py_DECREF(x_array);
@@ -193,7 +194,7 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
   NpyIter_IterNextFunc *iternext;
   char **dataptr;
   npy_intp *strideptr, *innersizeptr;
-  PyArray_Descr *dtypes[] = {PyArray_DescrFromType(NPY_DOUBLE), PyArray_DescrFromType(NPY_DOUBLE)};
+  PyArray_Descr *dtypes[2];
   npy_uint32 op_flags[] = {NPY_ITER_READONLY, NPY_ITER_READONLY};
 
   /* Parse the input tuple */
@@ -249,10 +250,14 @@ static PyObject *_histogram2d(PyObject *self, PyObject *args) {
 
   arrays[0] = x_array;
   arrays[1] = y_array;
+  dtypes[0] = PyArray_DescrFromType(NPY_DOUBLE);
+  dtypes[1] = PyArray_DescrFromType(NPY_DOUBLE);
   iter = NpyIter_AdvancedNew(2, arrays,
                              NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
                              NPY_KEEPORDER, NPY_SAFE_CASTING, op_flags, dtypes,
                              -1, NULL, NULL, 0);
+  Py_DECREF(dtypes[0]);
+  Py_DECREF(dtypes[1]);
   if (iter == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
     Py_DECREF(x_array);
@@ -413,6 +418,7 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
   /* copy the content of `bins` into `dims` */
   dtype = PyArray_DescrFromType(NPY_INTP);
   iter = NpyIter_New(bins, NPY_ITER_READONLY, NPY_CORDER, NPY_SAFE_CASTING, dtype);
+  Py_DECREF(dtype);
   if (iter == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator over binning.");
     for (int i = 0; i < ndim; i++){
@@ -479,6 +485,7 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
   range_c = (double *)malloc(sizeof(double) * ndim * 2);
   dtype = PyArray_DescrFromType(NPY_DOUBLE);
   iter = NpyIter_New(range, NPY_ITER_READONLY, NPY_CORDER, NPY_SAFE_CASTING, dtype);
+  Py_DECREF(dtype);
   if (iter == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator over range. This needs to be passed as type `numpy.double`.");
     for (int i = 0; i < ndim; i++){
@@ -534,6 +541,9 @@ static PyObject *_histogramdd(PyObject *self, PyObject *args) {
                              NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
                              NPY_KEEPORDER, NPY_SAFE_CASTING, op_flags, dtypes,
                              -1, NULL, NULL, 0);
+  for (int i = 0; i < ndim; i++){
+    Py_DECREF(dtypes[i]);
+  }
   if (iter == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
     for (int i = 0; i < ndim; i++){
@@ -667,7 +677,7 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args) {
   NpyIter_IterNextFunc *iternext;
   char **dataptr;
   npy_intp *strideptr, *innersizeptr;
-  PyArray_Descr *dtypes[] = {PyArray_DescrFromType(NPY_DOUBLE), PyArray_DescrFromType(NPY_DOUBLE)};
+  PyArray_Descr *dtypes[2];
   npy_uint32 op_flags[] = {NPY_ITER_READONLY, NPY_ITER_READONLY};
 
   /* Parse the input tuple */
@@ -722,10 +732,14 @@ static PyObject *_histogram1d_weighted(PyObject *self, PyObject *args) {
 
   arrays[0] = x_array;
   arrays[1] = w_array;
+  dtypes[0] = PyArray_DescrFromType(NPY_DOUBLE);
+  dtypes[1] = PyArray_DescrFromType(NPY_DOUBLE);
   iter = NpyIter_AdvancedNew(2, arrays,
                              NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
                              NPY_KEEPORDER, NPY_SAFE_CASTING, op_flags, dtypes,
                              -1, NULL, NULL, 0);
+  Py_DECREF(dtypes[0]);
+  Py_DECREF(dtypes[1]);
   if (iter == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
     Py_DECREF(x_array);
@@ -815,7 +829,7 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args) {
   NpyIter_IterNextFunc *iternext;
   char **dataptr;
   npy_intp *strideptr, *innersizeptr;
-  PyArray_Descr *dtypes[] = {PyArray_DescrFromType(NPY_DOUBLE), PyArray_DescrFromType(NPY_DOUBLE), PyArray_DescrFromType(NPY_DOUBLE)};
+  PyArray_Descr *dtypes[3];
   npy_uint32 op_flags[] = {NPY_ITER_READONLY, NPY_ITER_READONLY, NPY_ITER_READONLY};
 
   /* Parse the input tuple */
@@ -877,10 +891,16 @@ static PyObject *_histogram2d_weighted(PyObject *self, PyObject *args) {
   arrays[0] = x_array;
   arrays[1] = y_array;
   arrays[2] = w_array;
+  dtypes[0] = PyArray_DescrFromType(NPY_DOUBLE);
+  dtypes[1] = PyArray_DescrFromType(NPY_DOUBLE);
+  dtypes[2] = PyArray_DescrFromType(NPY_DOUBLE);
   iter = NpyIter_AdvancedNew(3, arrays,
                              NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
                              NPY_KEEPORDER, NPY_SAFE_CASTING, op_flags, dtypes,
                              -1, NULL, NULL, 0);
+  Py_DECREF(dtypes[0]);
+  Py_DECREF(dtypes[1]);
+  Py_DECREF(dtypes[2]);
   if (iter == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
     Py_DECREF(x_array);
@@ -1050,6 +1070,7 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
   /* copy the content of `bins` into `dims` */
   dtype = PyArray_DescrFromType(NPY_INTP);
   iter = NpyIter_New(bins, NPY_ITER_READONLY, NPY_CORDER, NPY_SAFE_CASTING, dtype);
+  Py_DECREF(dtype);
   if (iter == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator over binning.");
     for (int i = 0; i < ndim + 1; i++){
@@ -1116,6 +1137,7 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
   range_c = (double *)malloc(sizeof(double) * ndim * 2);
   dtype = PyArray_DescrFromType(NPY_DOUBLE);
   iter = NpyIter_New(range, NPY_ITER_READONLY, NPY_CORDER, NPY_SAFE_CASTING, dtype);
+  Py_DECREF(dtype);
   if (iter == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator over range. This needs to be passed as type `numpy.double`.");
     for (int i = 0; i < ndim + 1; i++){
@@ -1171,6 +1193,9 @@ static PyObject *_histogramdd_weighted(PyObject *self, PyObject *args) {
                              NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
                              NPY_KEEPORDER, NPY_SAFE_CASTING, op_flags, dtypes,
                              -1, NULL, NULL, 0);
+  for (int i = 0; i < ndim + 1; i++){
+    Py_DECREF(dtypes[i]);
+  }
   if (iter == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
     for (int i = 0; i < ndim + 1; i++){

--- a/fast_histogram/tests/test_histogram.py
+++ b/fast_histogram/tests/test_histogram.py
@@ -522,3 +522,15 @@ def test_invalid_list():
             bins=10,
             range=((0, 10), (0, 10), (0, 10)),
         )
+
+
+@pytest.mark.parametrize("use_weights", [False, True])
+def test_histogramdd_mismatched_lengths(use_weights):
+    # Regression test for a bug where the dimension-mismatch error cleanup
+    # loop used the wrong variable (arrays[i] instead of arrays[j]), causing
+    # a use-after-free on one array and leaking all others.
+    a = np.array([1.0, 2.0])
+    b = np.array([1.0, 2.0, 3.0])
+    w = np.array([1.0, 2.0]) if use_weights else None
+    with pytest.raises(RuntimeError, match="Lengths"):
+        histogramdd((a, b), bins=10, range=[(0, 10), (0, 10)], weights=w)


### PR DESCRIPTION
## Summary

Fix 7 memory safety and correctness bugs in `_histogram_core.c`, identified using the [cext-review-toolkit](https://github.com/devdanzin/cext-review-toolkit) plugin for Claude Code which performed a comprehensive automated audit of the C extension.

### Bugs fixed

- **Wrong loop variable in `_histogramdd` dimension-mismatch cleanup** (`arrays[i]` instead of `arrays[j]`) — caused a use-after-free on one array and leaked all others. Present since 2021 (c70b606). Triggers a segfault when sample arrays have different lengths.
- **Double-decref of `count_obj`/`count_array` on error paths** — `count_array` is just a cast of `count_obj` (same object), but both were DECREF'd in 8 error-path sites across `_histogram1d`, `_histogram2d`, `_histogram1d_weighted`, and `_histogram2d_weighted`. This causes heap corruption when iterator setup fails.
- **Unchecked `PyTuple_Size` return** in `_histogramdd` and `_histogramdd_weighted` — returns -1 on non-tuple input, causing negative `ndim` which wraps `malloc` sizes and leads to NULL dereference.
- **`PyArray_DescrFromType` reference leaks on every call** — `NpyIter_New`/`NpyIter_AdvancedNew` do not steal the dtype reference, so the `PyArray_Descr` from `PyArray_DescrFromType` was leaked on every invocation of all 6 functions. In the 2D and weighted variants, dtypes were also allocated at declaration time, leaking on every early-return path.
- **Unchecked `malloc` for `arrays`** in `_histogramdd` and `_histogramdd_weighted` — could segfault on OOM or with very large `ndim`.
- **Missing `Py_XDECREF(range)`/`Py_XDECREF(bins)`** on 4 late error paths in `_histogramdd` and `_histogramdd_weighted` — leaked numpy arrays when `NpyIter_AdvancedNew` or `NpyIter_GetIterNext` failed.
- **`Py_LIMITED_API` version mismatch** — C code claimed Python 3.9 (`0x030900f0`) but minimum Python is 3.10 and `setup.cfg` says `cp310`.

### Regression test

A parametrized test for the `arrays[i]`/`arrays[j]` bug is included — it segfaulted before the fix and now raises `RuntimeError` cleanly. The other fixes involve error paths unreachable via the public API (the Python wrapper validates inputs) or memory leaks that aren't deterministically testable.

